### PR TITLE
chore: add lsp logs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ node_modules/
 !.vscode/launch.json
 !.vscode/extensions.json
 
+# LSP
+.log/*
+
 # misc
 .sass-cache
 connect.lock


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
If you run the LSP server separately then it generates logs in the root folder. It has any sense only for local copy, so PR about to add folder '.log' to .gitignore. It'll make the project more IDE agnostic.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
git shouldn't track the ".log" folder in the root folder

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
