### PR TITLE
fix(libs): #118 fix Lib Form(Form.types.ts) wrong type definition

### DIFF
--- a/libs/components/ui/src/components/form/Form.types.ts
+++ b/libs/components/ui/src/components/form/Form.types.ts
@@ -1,4 +1,4 @@
-import { PropsFromKeys } from '@codelab/shared/interface/props'
+import { PropsFromKeys, PropJsonValue } from '@codelab/shared/interface/props'
 import { ReactNodeI } from '@codelab/shared/interface/node'
 import { Select } from '../select'
 
@@ -59,19 +59,19 @@ export namespace Form {
 
   export type ItemProps = PropsFromKeys<typeof itemPropKeys[number]>
 
-  export type OptionConfig<T = unknown> = [string, T]
+  export type OptionConfig = [string, PropJsonValue]
 
-  export interface CreateSelect<T = unknown> {
+  export interface CreateSelect {
     label: string
     name: string
-    options: OptionConfig<T>[]
+    options: Array<OptionConfig>
   }
 
-  export const createSelect = <T = unknown>({
+  export const createSelect = ({
     label,
     name,
     options,
-  }: CreateSelect<T>): ReactNodeI<Select.Props | Form.ItemProps> => ({
+  }: CreateSelect): ReactNodeI<Select.Props | Form.ItemProps> => ({
     type: 'Form.Item',
     nodeType: 'React',
     props: {
@@ -87,15 +87,15 @@ export namespace Form {
             width: 120,
           },
         },
-        children: Form.createOptions<T>(options),
+        children: Form.createOptions(options),
       },
     ],
   })
 
-  export const createOptions = <T = unknown>(
-    options: OptionConfig<T>[],
+  export const createOptions = (
+    options: Array<OptionConfig>,
   ): Array<ReactNodeI<Select.OptionProps>> =>
-    options.map(([key, value]: [string, any]) => ({
+    options.map(([key, value]: [string, PropJsonValue]) => ({
       type: 'Select.Option',
       nodeType: 'React',
       props: {

--- a/libs/components/ui/src/components/form/Form.types.ts
+++ b/libs/components/ui/src/components/form/Form.types.ts
@@ -1,9 +1,5 @@
 import { PropsFromKeys } from '@codelab/shared/interface/props'
-import {
-  ReactNodeI,
-  ReactNodeTypeEnum,
-  NodeTypeEnum,
-} from '@codelab/shared/interface/node'
+import { ReactNodeI } from '@codelab/shared/interface/node'
 import { Select } from '../select'
 
 export namespace Form {
@@ -63,17 +59,19 @@ export namespace Form {
 
   export type ItemProps = PropsFromKeys<typeof itemPropKeys[number]>
 
-  export interface CreateSelect {
+  export type OptionConfig<T = unknown> = [string, T]
+
+  export interface CreateSelect<T = unknown> {
     label: string
     name: string
-    options: typeof NodeTypeEnum
+    options: OptionConfig<T>[]
   }
 
-  export const createSelect = ({
+  export const createSelect = <T = unknown>({
     label,
     name,
     options,
-  }: CreateSelect): ReactNodeI<Select.Props | Form.ItemProps> => ({
+  }: CreateSelect<T>): ReactNodeI<Select.Props | Form.ItemProps> => ({
     type: 'Form.Item',
     nodeType: 'React',
     props: {
@@ -89,15 +87,15 @@ export namespace Form {
             width: 120,
           },
         },
-        children: Form.createOptions(options),
+        children: Form.createOptions<T>(options),
       },
     ],
   })
 
-  export const createOptions = (
-    type: typeof NodeTypeEnum,
+  export const createOptions = <T = unknown>(
+    options: OptionConfig<T>[],
   ): Array<ReactNodeI<Select.OptionProps>> =>
-    Object.entries(type).map(([key, value]: [string, any]) => ({
+    options.map(([key, value]: [string, any]) => ({
       type: 'Select.Option',
       nodeType: 'React',
       props: {

--- a/libs/components/ui/src/components/form/data/Form-4--node.data.ts
+++ b/libs/components/ui/src/components/form/data/Form-4--node.data.ts
@@ -18,7 +18,7 @@ export const nodeFormData: ReactNodeI<
     Form.createSelect({
       label: 'Node Type',
       name: 'node_type',
-      options: NodeTypeEnum,
+      options: Object.entries(NodeTypeEnum),
     }),
     {
       type: 'Form.Item',

--- a/libs/components/ui/src/components/select/Select.spec.tsx
+++ b/libs/components/ui/src/components/select/Select.spec.tsx
@@ -8,7 +8,6 @@ import {
 } from '@codelab/shared/interface/node'
 import { cLog } from '@codelab/shared/utils'
 import { Default } from './Select.stories'
-import { Select } from './Select.types'
 import { Form } from '../form/Form.types'
 
 describe('Select', () => {
@@ -28,7 +27,7 @@ describe('Select', () => {
       BTC = 'btc',
       ETH = 'eth',
     }
-    const options = Form.createOptions(Coins as any)
+    const options = Form.createOptions<string>(Object.entries(Coins))
 
     cLog(options)
 

--- a/libs/shared/interface/props/src/index.ts
+++ b/libs/shared/interface/props/src/index.ts
@@ -1,1 +1,7 @@
-export type { PropItem, PropValue, Props, PropsFromKeys } from './props'
+export type {
+  PropItem,
+  PropValue,
+  Props,
+  PropsFromKeys,
+  PropJsonValue,
+} from './props'

--- a/libs/shared/interface/props/src/props.ts
+++ b/libs/shared/interface/props/src/props.ts
@@ -18,3 +18,6 @@ export interface Props {
 export type PropsFromKeys<Keys extends string, P extends object = {}> = {
   [K in Keys]?: string | number | boolean | PropValue | P
 } & { ctx?: PropItem; style?: CSSProperties }
+
+// Accepted value from JSON representation
+export type PropJsonValue = string | number | boolean

--- a/libs/tools/eslint-config-codelab/.eslintrc.base.yml
+++ b/libs/tools/eslint-config-codelab/.eslintrc.base.yml
@@ -72,6 +72,9 @@ overrides:
         '@typescript-eslint/parser': ['.ts', '.tsx']
     rules:
       no-inner-declarations: off
+      '@typescript-eslint/array-type':
+        - error
+        - default: generic
       '@typescript-eslint/no-namespace': off
       '@typescript-eslint/no-useless-constructor': ['error']
       '@typescript-eslint/ban-types':


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Current Behavior

Described in #118 
<!-- This is the behavior we have today -->

## Expected Behavior

Described in #118 
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

#118 