### PR TITLE
refactor(libs-core-renderer): add the ability to specify the returned type for TreeDom renderer

### DIFF
--- a/apps/web/src/node/ButtonGroup.tsx
+++ b/apps/web/src/node/ButtonGroup.tsx
@@ -82,11 +82,9 @@ const nodeButtonGroupData: NodeDtoReactI = {
   ],
 }
 
-export interface NodeButtonGroupProps {
-  toggleform: () => void
-  handledelete: () => void
+export interface ButtonGroupProps {
+  setvisibility: Function
+  handledelete: Function
 }
 
-export const ButtonGroup = TreeDom.render<NodeButtonGroupProps>(
-  nodeButtonGroupData,
-)
+export const ButtonGroup = TreeDom.render<ButtonGroupProps>(nodeButtonGroupData)

--- a/apps/web/src/node/ModalForm.tsx
+++ b/apps/web/src/node/ModalForm.tsx
@@ -178,4 +178,10 @@ export const modalFormData: NodeDtoReactI = {
   ],
 }
 
-export const ModalForm = TreeDom.render(modalFormData)
+interface ModalFormProps {
+  handlesubmit: Function
+  visibility: boolean
+  setvisibility: Function
+}
+
+export const ModalForm = TreeDom.render<ModalFormProps>(modalFormData)

--- a/libs/components/ui/src/components/table/Table.tsx
+++ b/libs/components/ui/src/components/table/Table.tsx
@@ -6,6 +6,16 @@ import { TreeDom } from '@codelab/core/renderer'
 
 export type TableProps<T extends object = any> = AntTableProps<T>
 
+interface CellProps<T = any> {
+  // title: React.ReactNode
+  // editable: boolean
+  index: number
+  record: T
+  // children: React.ReactNode
+  // dataIndex: string
+  // handleSave: (record: T) => void
+}
+
 export namespace CodelabTable {
   export const Default = <T extends object = any>(props: TableProps<T>) => {
     const { dataSource, columns } = props
@@ -15,7 +25,7 @@ export namespace CodelabTable {
         return {
           ...column,
           render: (text: string, record: any, index: number) => {
-            const Cell = TreeDom.render(render)
+            const Cell = TreeDom.render<CellProps>(render)
 
             return <Cell record={record} index={index} />
           },

--- a/libs/core/renderer/src/TreeDom.tsx
+++ b/libs/core/renderer/src/TreeDom.tsx
@@ -23,7 +23,9 @@ const evalPropsWithTreeContext = (props: Props): Props => {
 }
 
 export class TreeDom {
-  static render<P extends Props = {}>(data: NodeDtoI): FunctionComponent<any> {
+  static render<P extends Props = {}>(
+    data: NodeDtoI,
+  ): FunctionComponent<PropsWithChildren<P>> {
     let hasRootChildren = false
     const root = makeTree(data) as Node
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Current Behavior
Even if you specify the type in generic in TreeDom.render, it will not validate the resulted React component props for validness 
<!-- This is the behavior we have today -->

## Expected Behavior
- Static analysis can validate React component props
- Autocompletion work 
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
