### PR TITLE
414 front end auth notifications and input-request refactoring

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -38,5 +38,6 @@ module.exports = {
     '<rootDir>/libs/modules/auth',
     '<rootDir>/libs/modules/app',
     '<rootDir>/libs/tools/generators/graphql',
+    '<rootDir>/libs/modules/notification-stories',
   ],
 }

--- a/libs/frontend/src/infrastructure/machine/machine-root.tsx
+++ b/libs/frontend/src/infrastructure/machine/machine-root.tsx
@@ -2,6 +2,7 @@ import { Machine, assign, spawn } from 'xstate'
 import { createAppMachine } from '@codelab/modules/app-stories'
 import { createGridMachine } from '@codelab/modules/grid-stories'
 import { layoutMachine } from '@codelab/modules/layout-stories'
+import { createNotificationMachine } from '@codelab/modules/notification-stories'
 import { createUserMachine } from '@codelab/modules/user-stories'
 
 export const rootMachine = Machine<any>({
@@ -11,22 +12,11 @@ export const rootMachine = Machine<any>({
     user: () => spawn(createUserMachine(), { sync: false, autoForward: true }),
     grid: () => spawn(createGridMachine(), { sync: false, autoForward: true }),
     app: () => spawn(createAppMachine(), { sync: false, autoForward: true }),
+    notification: () =>
+      spawn(createNotificationMachine(), { sync: false, autoForward: true }),
   }),
   initial: 'idle',
   states: {
-    idle: {
-      on: {
-        // ON_MODAL_CANCEL: {
-        //   actions: () => {
-        //     console.log('on modal cancel')
-        //   },
-        // },
-        // ON_MODAL_OK: {
-        //   actions: () => {
-        //     console.log('on modal ok')
-        //   },
-        // },
-      },
-    },
+    idle: {},
   },
 })

--- a/libs/modules/notification-stories/.babelrc
+++ b/libs/modules/notification-stories/.babelrc
@@ -1,0 +1,17 @@
+{
+  "presets": [
+    "@nrwl/react/babel",
+    "@babel/preset-env",
+    "@babel/preset-react",
+    "@babel/preset-typescript"
+  ],
+  "plugins": [
+    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allowNamespaces": true
+      }
+    ],
+    "@babel/plugin-proposal-class-properties"
+  ]
+}

--- a/libs/modules/notification-stories/.eslintrc.js
+++ b/libs/modules/notification-stories/.eslintrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  extends: '../../../.eslintrc.js',
+  root: true,
+  settings: {
+    'import/resolver': {
+      typescript: {
+        project: 'tsconfig.eslint.json',
+      },
+    },
+  },
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['tsconfig.eslint.json'],
+  },
+}

--- a/libs/modules/notification-stories/.storybook/main.js
+++ b/libs/modules/notification-stories/.storybook/main.js
@@ -1,0 +1,9 @@
+const rootMain = require('../../../../.storybook/main')
+
+// Use the following syntax to add addons!
+// rootMain.addons.push('')
+rootMain.stories.push(
+  ...['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+)
+
+module.exports = rootMain

--- a/libs/modules/notification-stories/.storybook/preview.js
+++ b/libs/modules/notification-stories/.storybook/preview.js
@@ -1,0 +1,5 @@
+import { withKnobs } from '@storybook/addon-knobs'
+import { addDecorator } from '@storybook/react'
+import '../../../../.storybook/preview'
+
+addDecorator(withKnobs)

--- a/libs/modules/notification-stories/.storybook/tsconfig.json
+++ b/libs/modules/notification-stories/.storybook/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "emitDecoratorMetadata": true
+  },
+  "exclude": [
+    "../**/*.spec.ts",
+    "../**/*.spec.js",
+    "../**/*.spec.tsx",
+    "../**/*.spec.jsx"
+  ],
+  "include": ["../src/**/*"]
+}

--- a/libs/modules/notification-stories/.storybook/webpack.config.js
+++ b/libs/modules/notification-stories/.storybook/webpack.config.js
@@ -1,0 +1,13 @@
+const rootWebpackConfig = require('../../../../.storybook/webpack.config')
+
+module.exports = async ({ config, mode }) => {
+  // eslint-disable-next-line no-param-reassign
+  config = await rootWebpackConfig({ config, mode })
+
+  config.module.rules.push({
+    test: /\.(ts|tsx)$/,
+    loader: require.resolve('babel-loader'),
+  })
+
+  return config
+}

--- a/libs/modules/notification-stories/README.md
+++ b/libs/modules/notification-stories/README.md
@@ -1,0 +1,7 @@
+# modules-notification-stories
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test modules-notification-stories` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/modules/notification-stories/babel-jest.config.json
+++ b/libs/modules/notification-stories/babel-jest.config.json
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "current"
+        }
+      }
+    ],
+    "@babel/preset-typescript",
+    "@babel/preset-react"
+  ]
+}

--- a/libs/modules/notification-stories/jest.config.js
+++ b/libs/modules/notification-stories/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  displayName: 'modules-notification-stories',
+  preset: '../../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]sx?$': [
+      'babel-jest',
+      { cwd: __dirname, configFile: './babel-jest.config.json' },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/libs/modules/notification-stories',
+}

--- a/libs/modules/notification-stories/src/index.ts
+++ b/libs/modules/notification-stories/src/index.ts
@@ -1,0 +1,3 @@
+export * from './store/ant-notification-action'
+export * from './store/machine-notification-event'
+export * from './store/machine-notification'

--- a/libs/modules/notification-stories/src/store/ant-notification-action.ts
+++ b/libs/modules/notification-stories/src/store/ant-notification-action.ts
@@ -1,0 +1,13 @@
+import { notification } from 'antd'
+import { ActionFunction } from 'xstate/lib/types'
+import { MachineNotificationEvent } from './machine-notification-event'
+
+export const antNotificationAction: ActionFunction<
+  any,
+  MachineNotificationEvent
+> = (context, event) => {
+  notification[event.notificationType || 'info']({
+    message: event.title,
+    description: event.content,
+  })
+}

--- a/libs/modules/notification-stories/src/store/machine-notification-event.ts
+++ b/libs/modules/notification-stories/src/store/machine-notification-event.ts
@@ -1,0 +1,8 @@
+type NotificationType = 'success' | 'info' | 'warning' | 'error'
+
+export interface MachineNotificationEvent {
+  type: 'NOTIFY'
+  notificationType: NotificationType
+  content?: string
+  title?: string
+}

--- a/libs/modules/notification-stories/src/store/machine-notification.ts
+++ b/libs/modules/notification-stories/src/store/machine-notification.ts
@@ -1,0 +1,25 @@
+import { Machine } from 'xstate'
+import { antNotificationAction } from './ant-notification-action'
+import { MachineNotificationEvent } from './machine-notification-event'
+
+export const createNotificationMachine = () => {
+  return Machine<any, any, MachineNotificationEvent>(
+    {
+      initial: 'notifying',
+      states: {
+        notifying: {
+          on: {
+            NOTIFY: {
+              actions: 'notify',
+            },
+          },
+        },
+      },
+    },
+    {
+      actions: {
+        notify: antNotificationAction,
+      },
+    },
+  )
+}

--- a/libs/modules/notification-stories/tsconfig.eslint.json
+++ b/libs/modules/notification-stories/tsconfig.eslint.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.json",
+    ".*.js"
+  ]
+}

--- a/libs/modules/notification-stories/tsconfig.json
+++ b/libs/modules/notification-stories/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./.storybook/tsconfig.json"
+    }
+  ]
+}

--- a/libs/modules/notification-stories/tsconfig.lib.json
+++ b/libs/modules/notification-stories/tsconfig.lib.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": ["node"]
+  },
+  "files": [
+    "../../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+    "../../../node_modules/@nrwl/react/typings/image.d.ts"
+  ],
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.js",
+    "**/*.stories.jsx",
+    "**/*.stories.tsx"
+  ],
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+}

--- a/libs/modules/notification-stories/tsconfig.spec.json
+++ b/libs/modules/notification-stories/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/libs/modules/user-stories/src/store/machine-user.ts
+++ b/libs/modules/user-stories/src/store/machine-user.ts
@@ -1,4 +1,4 @@
-import { Machine, assign } from 'xstate'
+import { Machine, assign, sendParent } from 'xstate'
 import { getMeServices } from '../useCases/getMe'
 import {
   registerUserService,
@@ -78,6 +78,10 @@ export const createUserMachine = () => {
                       userData: undefined,
                     }),
                     () => clearAuthTokenInLocalStorage(),
+                    sendParent({
+                      type: 'NOTIFY',
+                      title: 'You have been signed out',
+                    }),
                   ],
                 },
               },

--- a/libs/modules/user-stories/src/useCases/registerUser/RegisterUserForm.tsx
+++ b/libs/modules/user-stories/src/useCases/registerUser/RegisterUserForm.tsx
@@ -45,6 +45,9 @@ export const RegisterUserForm = ({
       onChange={(e) => setFormData(e.formData)}
       onSubmit={onSubmit}
     >
+      {/* This button exists because by default the Form from rjsf includes a submit button.
+       Since we don't want to use it and we want to submit with the modal button, we need to hide it.
+       So if we add our own button and hide it with display: none, it works */}
       <button
         ref={submitBtnRef}
         type="submit"

--- a/libs/modules/user-stories/src/useCases/registerUser/RegisterUserInput.generated.ts
+++ b/libs/modules/user-stories/src/useCases/registerUser/RegisterUserInput.generated.ts
@@ -4,6 +4,7 @@ export const RegisterUserGql = gql`
   mutation RegisterUser($input: RegisterUserInput!) {
     registerUser(input: $input) {
       email
+      accessToken
     }
   }
 `

--- a/libs/modules/user-stories/src/useCases/registerUser/RegisterUserInput.graphql
+++ b/libs/modules/user-stories/src/useCases/registerUser/RegisterUserInput.graphql
@@ -1,5 +1,6 @@
 mutation RegisterUser($input: RegisterUserInput!) {
   registerUser(input: $input) {
-    email
+    email,
+    accessToken
   }
 }

--- a/libs/modules/user-stories/src/useCases/registerUser/RegisterUserModal.tsx
+++ b/libs/modules/user-stories/src/useCases/registerUser/RegisterUserModal.tsx
@@ -1,19 +1,13 @@
-import { Alert, Modal } from 'antd'
+import { Modal } from 'antd'
 import React, { createRef } from 'react'
-import { useUserMachine } from '../../store/useUserMachine'
+import { useRootMachine } from '../../../../../frontend/src/infrastructure/machine/useRootMachine'
+import { useUserMachine } from '../../store'
 import { RegisterUserForm } from './RegisterUserForm'
-import { useRootMachine } from '@codelab/frontend'
 
 export const RegisterUserModal = () => {
   const root = useRootMachine()
   const user = useUserMachine()
   const submitBtnRef = createRef<HTMLButtonElement>()
-
-  const error =
-    user.state.event?.type === 'error.platform.executeRegister' &&
-    user.state.event?.data?.message
-      ? user.state.event.data.message
-      : undefined
 
   return (
     <Modal
@@ -35,8 +29,6 @@ export const RegisterUserModal = () => {
       }}
     >
       <RegisterUserForm hasSubmitButton={false} submitBtnRef={submitBtnRef} />
-
-      {error && <Alert message={error} type="error" />}
     </Modal>
   )
 }

--- a/libs/modules/user-stories/src/useCases/registerUser/RegisterUserService.ts
+++ b/libs/modules/user-stories/src/useCases/registerUser/RegisterUserService.ts
@@ -4,17 +4,15 @@ import { mutate } from '@codelab/alpha/shared/utils'
 import { getApolloClient } from '@codelab/frontend'
 
 export const registerUserService: Record<string, ServiceConfig<any, any>> = {
-  registerUser: (context, { data }) => {
-    console.log(data)
+  registerUser: async (context, { data }) => {
+    // TODO: remove sleeping from registerUserService and loginUserService
+    await new Promise((resolve) => setTimeout(resolve, 500))
 
-    // TODO: replace mock with real API call
-    const results = mutate(getApolloClient(), {
+    return mutate(getApolloClient(), {
       mutation: RegisterUserGql,
-      variables: data,
+      variables: {
+        input: data,
+      },
     })
-
-    console.log(results)
-
-    return results
   },
 }

--- a/libs/modules/user-stories/src/useCases/registerUser/RegisterUserState.ts
+++ b/libs/modules/user-stories/src/useCases/registerUser/RegisterUserState.ts
@@ -1,4 +1,4 @@
-import { assign } from 'xstate'
+import { assign, sendParent } from 'xstate'
 import { StateNodeConfig } from 'xstate/lib/types'
 import { storeAuthTokenInLocalStorage } from '../../store'
 
@@ -33,10 +33,23 @@ export const registerUserState: StateNodeConfig<any, any, any> = {
               storeAuthTokenInLocalStorage(
                 event.data.data.registerUser.accessToken,
               ),
+            sendParent({
+              type: 'NOTIFY',
+              title: 'You have registered successfully!',
+              notificationType: 'success',
+            }),
           ],
         },
         onError: {
           target: 'idle',
+          actions: sendParent((context, event) => {
+            return {
+              type: 'NOTIFY',
+              title: 'Error while registering',
+              content: event?.data?.message,
+              notificationType: 'error',
+            }
+          }),
         },
       },
       on: {

--- a/libs/modules/user-stories/src/useCases/userLogin/UserLoginForm.tsx
+++ b/libs/modules/user-stories/src/useCases/userLogin/UserLoginForm.tsx
@@ -44,6 +44,9 @@ export const UserLoginForm = ({
       onChange={(e) => setFormData(e.formData)}
       onSubmit={onSubmit}
     >
+      {/* This button exists because by default the Form from rjsf includes a submit button.
+       Since we don't want to use it and we want to submit with the modal button, we need to hide it.
+       So if we add our own button and hide it with display: none, it works */}
       <button
         ref={submitBtnRef}
         type="submit"

--- a/libs/modules/user-stories/src/useCases/userLogin/UserLoginModal.tsx
+++ b/libs/modules/user-stories/src/useCases/userLogin/UserLoginModal.tsx
@@ -1,6 +1,6 @@
 import { Alert, Modal } from 'antd'
 import React, { createRef } from 'react'
-import { useUserMachine } from '../../store/useUserMachine'
+import { useUserMachine } from '../../store'
 import { UserLoginForm } from './UserLoginForm'
 import { useRootMachine } from '@codelab/frontend'
 

--- a/libs/modules/user-stories/src/useCases/userLogin/UserLoginServices.ts
+++ b/libs/modules/user-stories/src/useCases/userLogin/UserLoginServices.ts
@@ -4,7 +4,9 @@ import { mutate } from '@codelab/alpha/shared/utils'
 import { getApolloClient } from '@codelab/frontend'
 
 export const userLoginServices: Record<string, ServiceConfig<any, any>> = {
-  executeLogIn: (context, { data }) => {
+  executeLogIn: async (context, { data }) => {
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
     return mutate(getApolloClient(), {
       mutation: UserLoginGql,
       variables: {

--- a/libs/modules/user-stories/src/useCases/userLogin/UserLoginState.ts
+++ b/libs/modules/user-stories/src/useCases/userLogin/UserLoginState.ts
@@ -1,4 +1,4 @@
-import { assign } from 'xstate'
+import { assign, sendParent } from 'xstate'
 import { StateNodeConfig } from 'xstate/lib/types'
 import { storeAuthTokenInLocalStorage } from '../../store'
 
@@ -34,10 +34,25 @@ export const userLoginState: StateNodeConfig<any, any, any> = {
               storeAuthTokenInLocalStorage(
                 event.data.data.loginUser.accessToken,
               ),
+            sendParent((context, event) => {
+              return {
+                type: 'NOTIFY',
+                notificationType: 'success',
+                title: `Welcome back, ${event.data?.data?.loginUser?.email}`,
+              }
+            }),
           ],
         },
         onError: {
           target: 'idle',
+          actions: sendParent((context, event) => {
+            return {
+              type: 'NOTIFY',
+              title: 'Error while logging you in',
+              content: event?.data?.message,
+              notificationType: 'error',
+            }
+          }),
         },
       },
       on: {

--- a/makefile
+++ b/makefile
@@ -205,7 +205,7 @@ unit-dev:
 
 unit-ci:
 	npx nx run-many \
-	--memoryLimit=4096 \
+	--memoryLimit=8192 \
 	--testPathPattern=[^i].spec.ts \
 	--target=test \
 	--all \

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -104,6 +104,9 @@
       ],
       "@codelab/tools/generators/graphql": [
         "libs/tools/generators/graphql/src/index.ts"
+      ],
+      "@codelab/modules/notification-stories": [
+        "libs/modules/notification-stories/src/index.ts"
       ]
     }
   },


### PR DESCRIPTION
 - [x] Refactor to https://github.com/codelab-ai/codelab.ai/blob/master/documentation/getting-started/3-project-architecture.md#input-vs-request
nx build tools-generators-graphql will generate the types

- [x] Add a 1 second delay to each request, this way we can test out our UI's
- [x]  After submit, the the button should be disabled loading state
- [x] On success the button state will revert as the modal closes
- [x]  Then either a success or error notification will appear