### PR TITLE
557 re render components

### DIFF
--- a/apps/web/src/graph/updateVertex/UpdateVertexForm.tsx
+++ b/apps/web/src/graph/updateVertex/UpdateVertexForm.tsx
@@ -17,7 +17,8 @@ interface UpdateVertexFormProps {
 }
 
 export const UpdateVertexForm = ({ vertex, pageId }: UpdateVertexFormProps) => {
-  const [mutate, { loading }] = useUpdateVertexMutation({
+  const [mutate] = useUpdateVertexMutation({
+    awaitRefetchQueries: true,
     refetchQueries: [
       {
         query: GetPageGql,

--- a/libs/alpha/ui/antd/src/components/rgl/RGL.tsx
+++ b/libs/alpha/ui/antd/src/components/rgl/RGL.tsx
@@ -26,7 +26,15 @@ export namespace RGL {
     return <ResponsiveGridLayout {...props}>{children}</ResponsiveGridLayout>
   }
 
-  export const Item: React.FC<ReactGridItem> = ({ children, ...props }) => {
-    return <div {...props}>children</div>
+  export const Item: React.FC<ReactGridItem['props']> = ({
+    children,
+    'data-grid': dataGrid,
+    ...props
+  }) => {
+    return (
+      <div {...props} data-grid={JSON.stringify(dataGrid)}>
+        {children}
+      </div>
+    )
   }
 }

--- a/libs/frontend/src/renderer/RenderComponents.tsx
+++ b/libs/frontend/src/renderer/RenderComponents.tsx
@@ -15,43 +15,26 @@ export const RenderChildren = (
   renderProps: object = {},
   handlers: DashboardHandlerProps,
 ): ReactNode | Array<ReactNode> => {
-  const children = node.children.reduce(
-    (Components: Array<ReactNode>, child: NodeA) => {
-      const [Child, props] = elementParameterFactory({
-        ...child,
-        handlers,
-      })
+  return node.children.map((child: NodeA) => {
+    // TODO: remove any cast
+    const [Child, props] = elementParameterFactory({
+      ...child,
+      handlers,
+    }) as any
 
-      // TODO: remove any cast
-      const ChildComponent: ReactNode = hasChildren(child)
-        ? React.createElement(
-            Child as any,
-            {
-              key: child.id,
-              ...props,
-              className: 'Builder-node',
-              // ...child.evalProps(oldRenderProps)
-            },
-            RenderChildren(
+    return (
+      <Child key={child.id} {...props} className="Builder-node">
+        {hasChildren(child)
+          ? RenderChildren(
               child,
               props,
               handlers,
               // child.nextRenderProps(oldRenderProps)
-            ),
-          )
-        : React.createElement(Child as any, {
-            key: child.id,
-            ...props,
-            className: 'Builder-node',
-            // ...child.evalProps(oldRenderProps),
-          })
-
-      return [...Components, ChildComponent]
-    },
-    [],
-  )
-
-  return children
+            )
+          : null}
+      </Child>
+    )
+  })
 }
 
 export const RenderComponents = (node: NodeA) => {
@@ -68,15 +51,11 @@ export const RenderComponents = (node: NodeA) => {
     type,
     props: node.props,
     handlers,
-  })
+  }) as any
 
   return (
-    <>
-      {React.createElement(
-        RootComponent as any,
-        props,
-        RenderChildren(node, {}, handlers),
-      )}
-    </>
+    <RootComponent {...props}>
+      {RenderChildren(node, {}, handlers)}
+    </RootComponent>
   )
 }

--- a/libs/frontend/src/renderer/elementFactory.tsx
+++ b/libs/frontend/src/renderer/elementFactory.tsx
@@ -82,7 +82,7 @@ export const elementParameterFactory = ({
   handlers,
 }: {
   type: VertexType
-  props?: object
+  props?: Record<string, any>
   handlers: DashboardHandlerProps // Function hooks injected to pass to handlers
 }): [ReactHTMLElement<any> | React.FunctionComponent<any> | string, object] => {
   switch (type) {
@@ -163,7 +163,19 @@ export const elementParameterFactory = ({
     case VertexType.React_RGL_Container:
       return [RGL.Container, props]
     case VertexType.React_RGL_Item:
-      return ['div', props]
+      return [
+        RGL.Item,
+        // Currently the react-grid-layout library, for some reason, re-renders the layout
+        // only if it detects a change in the key of the child, and doesn't care about the data-grid property
+        // So, a workaround is to incorporate the data-grid property into the key to make sure we rerender
+        // There is a fix here https://github.com/STRML/react-grid-layout/issues/718, but for some reason it's not merged into the main repo
+        {
+          ...props,
+          key: props['data-grid']
+            ? props.key + JSON.stringify(props['data-grid'])
+            : props.key,
+        },
+      ]
     case VertexType.React_RGL_ResponsiveContainer:
       return [
         RGL.ResponsiveContainer,

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "react": "16.13.1",
     "react-cytoscapejs": "1.2.1",
     "react-dom": "16.13.1",
-    "react-grid-layout": "1.1.1",
+    "react-grid-layout": "^1.2.0",
     "react-highlight": "0.12.0",
     "react-json-view": "1.19.1",
     "react-json-view-ssr": "1.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20523,10 +20523,10 @@ react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-grid-layout@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-grid-layout/-/react-grid-layout-1.1.1.tgz#2643f84b95298e9c23d5e66ef86d7098a7184759"
-  integrity sha512-qrFzp94nG9NWWLcmZMvgqfi0TyOZ9JwjlvAc+2uywg8rYtZm/fLp33Io8XHJCfYOHzQrtZgXzEQBUvjO9XtL+g==
+react-grid-layout@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-grid-layout/-/react-grid-layout-1.2.0.tgz#87124d549c86c8df8841666618c8c3e3cb205c26"
+  integrity sha512-fJMGQFguphkAs0NsLNf8hz9cUv9B642JYei2yddiPby/X/kJ4HFIaMUhhqg1ArVfn/vHet1+h+LE4n85cFPh+Q==
   dependencies:
     classnames "2.x"
     lodash.isequal "^4.0.0"


### PR DESCRIPTION
Currently, the react-grid-layout library re-renders the layout
only if it detects a change in the key of the child, and doesn't care about the data-grid property
So, a workaround is to incorporate the data-grid property into the key to make sure we rerender it
 
There seems to be a fix [here](https://github.com/STRML/react-grid-layout/issues/718),  but it doesn't appear in the main codebase

fixes #557