### PR TITLE
feat(libs-plugins-codelab): #0 expanded use case generators

### DIFF
--- a/libs/plugins/codelab/src/generators/api-use-case/files/use-cases/__useCaseKebabCase__/__useCaseKebabCase__.service.ts__template__
+++ b/libs/plugins/codelab/src/generators/api-use-case/files/use-cases/__useCaseKebabCase__/__useCaseKebabCase__.service.ts__template__
@@ -1,12 +1,61 @@
-import { Inject, Injectable } from '@nestjs/common'
+import { Injectable } from '@nestjs/common'
 import { <%= modelNamePascalCase %> } from '../../<%= modelName %>.model'
-import { Mutation, Txn } from 'dgraph-js-http'
-import { <%= useCaseNamePascalCase %>Input } from './<%= useCaseNamePascalCase %>Input'
-import { DgraphUseCase } from '@codelab/backend'
+import { <%= useCaseNamePascalCase %>Input } from './<%= useCaseKebabCase %>.input'
+<% if(useCaseType === "dgraph") { %>
+  import { Txn } from 'dgraph-js-http'
+  import { DGraphService, <%= useCaseBaseClass %> } from '@codelab/backend'
+<% } else if(useCaseType === "mutation" || useCaseType === "query"){ %>
+  import { ApolloClientService, <%= useCaseBaseClass %> } from '@codelab/backend'
+  import { FetchResult } from '@apollo/client'
+  <% if(useCaseType === "query"){ %>
+    import { <%= useCaseNamePascalCase %>Gql, <%= useCaseNamePascalCase %>Query, <%= useCaseNamePascalCase %>QueryVariables } from '@codelab/dgraph'
+  <% } else { %>
+    import { <%= useCaseNamePascalCase %>Gql, <%= useCaseNamePascalCase %>Mutation, <%= useCaseNamePascalCase %>MutationVariables } from '@codelab/dgraph'
+  <% } %>
+<% } else { %>
+  import { <%= useCaseBaseClass %> } from '@codelab/backend'
+<% } %>
+
+<% if(useCaseType === "query"){ %>
+type GqlVariablesType = <%= useCaseNamePascalCase %>QueryVariables
+type GqlOperationType = <%= useCaseNamePascalCase %>Query
+<% } else if(useCaseType === "mutation") { %>
+type GqlVariablesType = <%= useCaseNamePascalCase %>MutationVariables
+type GqlOperationType = <%= useCaseNamePascalCase %>Mutation
+<% } %>
 
 @Injectable()
-export class <%= useCaseNamePascalCase %>Service extends DgraphUseCase<<%= useCaseNamePascalCase %>Input, <%= modelNamePascalCase %>> {
-  async execute(request: <%= useCaseNamePascalCase %>Input, txn: Txn) {
-    return (await Promise.resolve({})) as Promise<<%= modelNamePascalCase %>>
-  }
+export class <%= useCaseNamePascalCase %>Service <% if(useCaseType === "regular"){ %> implements <% } else { %> extends <% } %> <%= useCaseBaseClass %><<%= useCaseNamePascalCase %>Input, <%= modelNamePascalCase %> <% if(useCaseType === "mutation" || useCaseType === "query"){ %>,GqlOperationType, GqlVariablesType <% } %> > {
+  <% if(useCaseType === "mutation" || useCaseType === "query"){ %>
+    constructor(apollo: ApolloClientService) {
+      super(apollo)
+    }
+
+    protected getGql() {
+      return <%= useCaseNamePascalCase %>Gql
+    }
+
+    protected extractDataFromResult(result: FetchResult<GqlOperationType>) {
+      return null
+    }
+
+    protected getVariables(
+      request: <%= useCaseNamePascalCase %>Input,
+    ): GqlVariablesType {
+      return {}
+    }
+  <% } else if(useCaseType === "dgraph") { %>
+    constructor(dgraph: DGraphService) {
+      super(dgraph)
+    }
+
+
+    async executeTransaction(request: <%= useCaseNamePascalCase %>Input, txn: Txn) {
+      return (await Promise.resolve({})) as Promise<<%= modelNamePascalCase %>>
+    }
+  <% } else { %>
+    async execute(request: <%= useCaseNamePascalCase %>Input) {
+      return null
+    }
+  <% }  %>
 }

--- a/libs/plugins/codelab/src/generators/api-use-case/files/use-cases/__useCaseKebabCase__/index.ts__template__
+++ b/libs/plugins/codelab/src/generators/api-use-case/files/use-cases/__useCaseKebabCase__/index.ts__template__
@@ -1,0 +1,2 @@
+export * from './<%= useCaseKebabCase %>.input'
+export * from './<%= useCaseKebabCase %>.service'

--- a/libs/plugins/codelab/src/generators/api-use-case/generator.ts
+++ b/libs/plugins/codelab/src/generators/api-use-case/generator.ts
@@ -9,6 +9,14 @@ import {
 import * as path from 'path'
 import { toCamelCase, toKebabCase, toPascalCase } from '../utils'
 import { ApiUseCaseGeneratorSchema, NormalizedSchema } from './schema'
+import { UseCaseType } from './useCaseType'
+
+const useCaseToClassMap: Record<UseCaseType, string> = {
+  [UseCaseType.Regular]: 'UseCase',
+  [UseCaseType.Dgraph]: 'DgraphUseCase',
+  [UseCaseType.Mutation]: 'MutationUseCase',
+  [UseCaseType.Query]: 'QueryUseCase',
+}
 
 const normalizeOptions = (
   host: Tree,
@@ -23,7 +31,7 @@ const normalizeOptions = (
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-')
 
   // const projectRoot = `${getWorkspaceLayout(host).libsDir}/${projectDirectory}`
-  const { sourceRoot: projectRoot, root } = readProjectConfiguration(
+  const { sourceRoot: projectRoot } = readProjectConfiguration(
     host,
     projectName,
   )
@@ -36,6 +44,8 @@ const normalizeOptions = (
     ? options.tags.split(',').map((s) => s.trim())
     : []
 
+  options.useCaseType = options.useCaseType || UseCaseType.Regular
+
   const useCaseName = toCamelCase(options.useCaseName)
   const useCaseNamePascalCase = toPascalCase(useCaseName)
   const useCaseKebabCase = toKebabCase(useCaseName)
@@ -44,6 +54,7 @@ const normalizeOptions = (
 
   return {
     ...options,
+    useCaseBaseClass: useCaseToClassMap[options.useCaseType],
     useCaseNamePascalCase,
     useCaseName,
     modelName,

--- a/libs/plugins/codelab/src/generators/api-use-case/schema.d.ts
+++ b/libs/plugins/codelab/src/generators/api-use-case/schema.d.ts
@@ -1,9 +1,12 @@
+import { UseCaseType } from './useCaseType'
+
 export interface ApiUseCaseGeneratorSchema {
   name: string
   useCaseName: string
   modelName: string
   tags?: string
   directory?: string
+  useCaseType?: UseCaseType
 }
 
 export interface NormalizedSchema extends ApiUseCaseGeneratorSchema {
@@ -11,7 +14,7 @@ export interface NormalizedSchema extends ApiUseCaseGeneratorSchema {
   projectRoot: string
   projectDirectory: string
   parsedTags: Array<string>
-
+  useCaseBaseClass: string
   useCaseNamePascalCase: string
   modelNamePascalCase: string
   useCaseKebabCase: string

--- a/libs/plugins/codelab/src/generators/api-use-case/schema.json
+++ b/libs/plugins/codelab/src/generators/api-use-case/schema.json
@@ -32,6 +32,33 @@
       "type": "string",
       "description": "A directory where the project is placed",
       "alias": "d"
+    },
+    "useCaseType": {
+      "type": "string",
+      "description": "regular, dgraph, mutation or query",
+      "enum": ["regular", "dgraph", "mutation", "query"],
+      "x-prompt": {
+        "message": "What type of use case is this?",
+        "type": "list",
+        "items": [
+          {
+            "value": "regular",
+            "label": "Regular"
+          },
+          {
+            "value": "dgraph",
+            "label": "DQL use case"
+          },
+          {
+            "value": "mutation",
+            "label": "GraphQL Mutation"
+          },
+          {
+            "value": "query",
+            "label": "GraphQL Query"
+          }
+        ]
+      }
     }
   },
   "required": ["name"]

--- a/libs/plugins/codelab/src/generators/api-use-case/useCaseType.ts
+++ b/libs/plugins/codelab/src/generators/api-use-case/useCaseType.ts
@@ -1,0 +1,6 @@
+export enum UseCaseType {
+  Regular = 'regular',
+  Dgraph = 'dgraph',
+  Mutation = 'mutation',
+  Query = 'query',
+}


### PR DESCRIPTION
Added option for generating:
- Regular use case
- Query use case
- Mutation use case
- Dgraph use case

<img width="564" alt="Screenshot 2021-05-25 at 14 29 56" src="https://user-images.githubusercontent.com/57956282/119490880-ff72eb00-bd65-11eb-9391-7f9e23122377.png">

<img width="860" alt="Screenshot 2021-05-25 at 14 30 26" src="https://user-images.githubusercontent.com/57956282/119490911-0994e980-bd66-11eb-8c01-1f4fa30666c3.png">
<img width="900" alt="Screenshot 2021-05-25 at 14 30 51" src="https://user-images.githubusercontent.com/57956282/119490916-0b5ead00-bd66-11eb-951d-f290b6dedc3b.png">
<img width="909" alt="Screenshot 2021-05-25 at 14 31 12" src="https://user-images.githubusercontent.com/57956282/119490921-0bf74380-bd66-11eb-9919-05ba0c114fad.png">
<img width="901" alt="Screenshot 2021-05-25 at 14 31 26" src="https://user-images.githubusercontent.com/57956282/119490927-0c8fda00-bd66-11eb-94fa-215afb03dedf.png">

