### PR TITLE
chore: remove throwing on not found in getModel queries

### DIFF
--- a/libs/modules/app-api/src/app.resolver.ts
+++ b/libs/modules/app-api/src/app.resolver.ts
@@ -48,7 +48,7 @@ export class AppResolver {
     return this.createAppService.execute({ input, ownerId: user.sub })
   }
 
-  @Query(() => App)
+  @Query(() => App, { nullable: true })
   @UseGuards(GqlAuthGuard)
   async getApp(
     @Args('input') input: GetAppInput,
@@ -58,6 +58,10 @@ export class AppResolver {
       input,
       currentUser,
     })
+
+    if (!app) {
+      return null
+    }
 
     return this.appMapper.map(app)
   }

--- a/libs/modules/app-api/src/use-cases/delete-app/test/delete-app.i.spec.ts
+++ b/libs/modules/app-api/src/use-cases/delete-app/test/delete-app.i.spec.ts
@@ -65,12 +65,13 @@ describe('DeleteApp', () => {
       )
 
       // Should fail to get the deleted app
-      await domainRequest<GetAppInput, GetAppQuery>(
+      const { getApp } = await domainRequest<GetAppInput, GetAppQuery>(
         userApp,
         GetAppGql,
         getAppInput,
-        { message: 'Not found' },
       )
+
+      expect(getApp).toBeNull()
 
       // TODO make sure pages are deleted too
     })

--- a/libs/modules/atom-api/src/infrastructure/atom.resolver.ts
+++ b/libs/modules/atom-api/src/infrastructure/atom.resolver.ts
@@ -5,7 +5,6 @@ import {
   GqlAuthGuard,
   Void,
 } from '@codelab/backend'
-import { GetTypeService } from '@codelab/modules/type-api'
 import { Injectable, UseGuards } from '@nestjs/common'
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql'
 import {
@@ -33,7 +32,6 @@ export class AtomResolver {
     private getAtomsService: GetAtomsService,
     private deleteAtomService: DeleteAtomService,
     private updateAtomService: UpdateAtomService,
-    private getTypeService: GetTypeService,
     private atomMapper: AtomMapper,
   ) {
     this.atomsMapper = new ArrayMapper(atomMapper)

--- a/libs/modules/atom-api/src/use-cases/delete-atom/test/delete-atom.i.spec.ts
+++ b/libs/modules/atom-api/src/use-cases/delete-atom/test/delete-atom.i.spec.ts
@@ -69,12 +69,13 @@ describe('DeleteAtom', () => {
       )
 
       // Should fail to get the deleted atom
-      await domainRequest<GetAtomInput, GetAtomQuery>(
+      const { atom } = await domainRequest<GetAtomInput, GetAtomQuery>(
         userApp,
         GetAtomGql,
         getAtomInput,
-        { message: 'Not found' },
       )
+
+      expect(atom).toBeNull()
     })
   })
 })

--- a/libs/modules/atom-api/src/use-cases/get-atom/get-atom.service.ts
+++ b/libs/modules/atom-api/src/use-cases/get-atom/get-atom.service.ts
@@ -4,7 +4,6 @@ import {
   DgraphEntityType,
   DgraphQueryBuilder,
   DgraphUseCase,
-  NotFoundError,
 } from '@codelab/backend'
 import { Injectable } from '@nestjs/common'
 import { Txn } from 'dgraph-js-http'
@@ -27,27 +26,20 @@ export class GetAtomService extends DgraphUseCase<
     this.validate(request)
 
     if (request.byId) {
-      return this.dgraph.getOneOrThrow(
-        txn,
-        this.createGetByIdQuery(request.byId),
-      )
+      return this.dgraph.getOne(txn, this.createGetByIdQuery(request.byId))
     }
 
     if (request.byType) {
-      return this.dgraph.getOneOrThrow(
-        txn,
-        this.createGetByType(request.byType),
-      )
+      return this.dgraph.getOne(txn, this.createGetByType(request.byType))
     }
 
     if (request.byElement) {
       return this.dgraph
-        .getOneOrThrow<DgraphElement>(
+        .getOne<DgraphElement>(
           txn,
           this.createGetByElementQuery(request.byElement),
-          () => new NotFoundError('Element not found'),
         )
-        .then((e) => e.atom || null)
+        .then((e) => e?.atom || null)
     }
 
     throw new Error('Bad input to GetAtomsService')

--- a/libs/modules/element-api/src/component/component.resolver.ts
+++ b/libs/modules/element-api/src/component/component.resolver.ts
@@ -48,35 +48,47 @@ export class ComponentResolver {
     return this.createComponentService.execute({ input, currentUser })
   }
 
-  @Query(() => Component)
+  @Query(() => Component, { nullable: true })
   @UseGuards(GqlAuthGuard)
   async getComponent(
     @Args('input') input: GetComponentInput,
     @CurrentUser() currentUser: JwtPayload,
-  ) {
+  ): Promise<Component | null> {
     const dgraphComponent = await this.getComponentService.execute({
       input,
       currentUser,
     })
+
+    if (!dgraphComponent) {
+      return null
+    }
 
     return this.componentMapper.map(dgraphComponent)
   }
 
-  @Query(() => ElementGraph)
+  @Query(() => ElementGraph, { nullable: true })
   @UseGuards(GqlAuthGuard)
   async getComponentElements(
     @Args('input') input: GetComponentInput,
     @CurrentUser() currentUser: JwtPayload,
-  ) {
+  ): Promise<ElementGraph | null> {
     const dgraphComponent = await this.getComponentService.execute({
       input,
       currentUser,
     })
+
+    if (!dgraphComponent) {
+      return null
+    }
 
     const dgraphElement = await this.getElementService.execute({
       input: { elementId: dgraphComponent.root.uid },
       currentUser,
     })
+
+    if (!dgraphElement) {
+      return null
+    }
 
     return this.elementTreeTransformer.transform(dgraphElement)
   }

--- a/libs/modules/element-api/src/component/use-cases/get-component/get-component.service.ts
+++ b/libs/modules/element-api/src/component/use-cases/get-component/get-component.service.ts
@@ -12,7 +12,7 @@ import { GetComponentRequest } from './get-component.request'
 @Injectable()
 export class GetComponentService extends DgraphUseCase<
   GetComponentRequest,
-  DgraphComponent
+  DgraphComponent | null
 > {
   constructor(dgraph: DgraphRepository) {
     super(dgraph)
@@ -23,7 +23,7 @@ export class GetComponentService extends DgraphUseCase<
       input: { componentId },
     } = request
 
-    return this.dgraph.getOneOrThrow<DgraphComponent>(
+    return this.dgraph.getOne<DgraphComponent>(
       txn,
       this.createQuery(componentId),
     )

--- a/libs/modules/element-api/src/element.resolver.ts
+++ b/libs/modules/element-api/src/element.resolver.ts
@@ -64,6 +64,10 @@ export class ElementResolver {
       currentUser,
     })
 
+    if (!dgraphElement) {
+      return null
+    }
+
     return await this.elementTreeTransformer.transform(dgraphElement)
   }
 
@@ -83,6 +87,10 @@ export class ElementResolver {
       input,
       currentUser,
     })
+
+    if (!dgraphElement) {
+      return null
+    }
 
     return this.elementMapper.map(dgraphElement)
   }

--- a/libs/modules/element-api/src/use-cases/delete-element/test/delete-element.i.spec.ts
+++ b/libs/modules/element-api/src/use-cases/delete-element/test/delete-element.i.spec.ts
@@ -64,12 +64,13 @@ describe('DeleteElement', () => {
       )
 
       // Should fail to get the deleted element
-      await domainRequest<GetElementInput, GetElementQuery>(
+      const element = await domainRequest<GetElementInput, GetElementQuery>(
         userApp,
         GetElementGql,
         getElementInput,
-        { message: 'Element not found' },
       )
+
+      expect(element.getElement).toBeNull()
     })
   })
 })

--- a/libs/modules/element-api/src/use-cases/delete-element/test/delete-element.i.spec.ts
+++ b/libs/modules/element-api/src/use-cases/delete-element/test/delete-element.i.spec.ts
@@ -64,13 +64,12 @@ describe('DeleteElement', () => {
       )
 
       // Should fail to get the deleted element
-      const element = await domainRequest<GetElementInput, GetElementQuery>(
-        userApp,
-        GetElementGql,
-        getElementInput,
-      )
+      const { getElement } = await domainRequest<
+        GetElementInput,
+        GetElementQuery
+      >(userApp, GetElementGql, getElementInput)
 
-      expect(element.getElement).toBeNull()
+      expect(getElement).toBeNull()
     })
   })
 })

--- a/libs/modules/element-api/src/use-cases/get-element-graph/get-element-graph.service.ts
+++ b/libs/modules/element-api/src/use-cases/get-element-graph/get-element-graph.service.ts
@@ -3,7 +3,6 @@ import {
   DgraphEntityType,
   DgraphRepository,
   DgraphUseCase,
-  NotFoundError,
 } from '@codelab/backend'
 import { Injectable } from '@nestjs/common'
 import { Txn } from 'dgraph-js-http'
@@ -17,7 +16,7 @@ import { GetElementGraphRequest } from './get-element-graph.request'
  */
 export class GetElementGraphService extends DgraphUseCase<
   GetElementGraphRequest,
-  DgraphElement
+  DgraphElement | null
 > {
   constructor(
     protected readonly dgraph: DgraphRepository,
@@ -29,13 +28,12 @@ export class GetElementGraphService extends DgraphUseCase<
   protected async executeTransaction(
     request: GetElementGraphRequest,
     txn: Txn,
-  ): Promise<DgraphElement> {
+  ) {
     await this.validate(request)
 
-    return this.dgraph.getOneOrThrow(
+    return this.dgraph.getOne<DgraphElement>(
       txn,
       GetElementGraphService.createQuery(request),
-      () => new NotFoundError('Element not found'),
     )
   }
 

--- a/libs/modules/lambda-api/src/use-cases/delete-lambda/test/delete-lambda.i.spec.ts
+++ b/libs/modules/lambda-api/src/use-cases/delete-lambda/test/delete-lambda.i.spec.ts
@@ -68,13 +68,13 @@ describe('DeleteLambda', () => {
         deleteLambdaInput,
       )
 
-      const results = await domainRequest<GetLambdaInput, GetLambdaQuery>(
+      const { getLambda } = await domainRequest<GetLambdaInput, GetLambdaQuery>(
         userApp,
         GetLambdaGql,
         getLambdaInput,
       )
 
-      expect(results.getLambda).toBeNull()
+      expect(getLambda).toBeNull()
     })
   })
 })

--- a/libs/modules/page-api/src/use-cases/get-page/get-page.service.ts
+++ b/libs/modules/page-api/src/use-cases/get-page/get-page.service.ts
@@ -11,7 +11,10 @@ import { PageValidator } from '../../page.validator'
 import { GetPageRequest } from './get-page.request'
 
 @Injectable()
-export class GetPageService extends DgraphUseCase<GetPageRequest, DgraphPage> {
+export class GetPageService extends DgraphUseCase<
+  GetPageRequest,
+  DgraphPage | null
+> {
   constructor(dgraph: DgraphRepository, private pageValidator: PageValidator) {
     super(dgraph)
   }
@@ -23,7 +26,7 @@ export class GetPageService extends DgraphUseCase<GetPageRequest, DgraphPage> {
 
     await this.validate(request)
 
-    return this.dgraph.getOneOrThrow<DgraphPage>(
+    return this.dgraph.getOne<DgraphPage>(
       txn,
       GetPageService.createQuery(pageId),
     )

--- a/libs/modules/type-api/src/use-cases/type/delete-type/test/delete-type.i.spec.ts
+++ b/libs/modules/type-api/src/use-cases/type/delete-type/test/delete-type.i.spec.ts
@@ -70,9 +70,13 @@ describe('DeleteType', () => {
         deleteTypeInput,
       )
 
-      await domainRequest<GetTypeInput, GetTypeQuery>(userApp, GetTypeGql, {
-        where: { id: typeId },
-      })
+      const type = await domainRequest<GetTypeInput, GetTypeQuery>(
+        userApp,
+        GetTypeGql,
+        { where: { id: typeId } },
+      )
+
+      expect(type.getType).toBeNull()
     })
   })
 })

--- a/schema.api.graphql
+++ b/schema.api.graphql
@@ -347,7 +347,7 @@ type LambdaPayload {
 type Page {
   id: ID!
   name: String!
-  elements: ElementGraph!
+  elements: ElementGraph
 }
 
 type Tag {
@@ -398,12 +398,12 @@ type User {
 }
 
 type Query {
-  getApp(input: GetAppInput!): App!
+  getApp(input: GetAppInput!): App
   getApps: [App!]!
   getMe: User!
   getUsers(input: GetUsersInput): [User!]!
   getPages(input: GetPagesInput!): [Page!]!
-  getPage(input: GetPageInput!): Page!
+  getPage(input: GetPageInput!): Page
 
   """
   Aggregates the requested element and all of its descendant elements (infinitely deep) in the form of a flat array of Element and array of ElementEdge
@@ -412,8 +412,8 @@ type Query {
 
   """Get a single element."""
   getElement(input: GetElementInput!): Element
-  getComponent(input: GetComponentInput!): Component!
-  getComponentElements(input: GetComponentInput!): ElementGraph!
+  getComponent(input: GetComponentInput!): Component
+  getComponentElements(input: GetComponentInput!): ElementGraph
   getComponents: [Component!]!
   getAtoms: [Atom!]!
   getAtom(input: GetAtomInput!): Atom


### PR DESCRIPTION
Before some getX resolvers threw NotFound error (i.e. used getOneOrThrow from DgraphRepository)
This was inconsistent 
Now all getX resolvers return null if not found