### PR TITLE
feat: add encoded props for layout components

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-# yarn lint:graphql
-
 yarn cross-env TIMING=1 lint-staged --verbose
-
-# ./libs/tools/scripts/src/lint/git.sh

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-# Update schema
 yarn cli dgraph update-schema --env test
 
 make build-dev-affected

--- a/libs/backend/modules/atom/src/domain/data/Divider.json
+++ b/libs/backend/modules/atom/src/domain/data/Divider.json
@@ -1,0 +1,165 @@
+[
+  {
+    "__typename": "Atom",
+    "api": {
+      "__typename": "InterfaceType",
+      "id": "0x49",
+      "name": "Divider API",
+      "typeGraph": {
+        "__typename": "TypeGraph",
+        "edges": [
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "The className of container",
+              "id": "0x4a",
+              "key": "className",
+              "name": "ClassName"
+            },
+            "kind": "Field",
+            "source": "0x49",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Whether line is dashed",
+              "id": "0x4b",
+              "key": "dashed",
+              "name": "Dashed"
+            },
+            "kind": "Field",
+            "source": "0x49",
+            "target": "0x34"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "The position of title inside divider",
+              "id": "0x53",
+              "key": "orientation",
+              "name": "Orientation"
+            },
+            "kind": "Field",
+            "source": "0x49",
+            "target": "0x5e"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Divider text show as plain style",
+              "id": "0x54",
+              "key": "plain",
+              "name": "Plain"
+            },
+            "kind": "Field",
+            "source": "0x49",
+            "target": "0x34"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "The style object of container",
+              "id": "0x55",
+              "key": "style",
+              "name": "Style"
+            },
+            "kind": "Field",
+            "source": "0x49",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "The direction type of divider",
+              "id": "0x56",
+              "key": "type",
+              "name": "Type"
+            },
+            "kind": "Field",
+            "source": "0x49",
+            "target": "0x57"
+          }
+        ],
+        "vertices": [
+          {
+            "__typename": "InterfaceType",
+            "id": "0x49",
+            "name": "Divider API",
+            "typeKind": "InterfaceType"
+          },
+          {
+            "__typename": "PrimitiveType",
+            "id": "0x32",
+            "name": "String",
+            "primitiveKind": "String",
+            "typeKind": "PrimitiveType"
+          },
+          {
+            "__typename": "PrimitiveType",
+            "id": "0x34",
+            "name": "Boolean",
+            "primitiveKind": "Boolean",
+            "typeKind": "PrimitiveType"
+          },
+          {
+            "__typename": "EnumType",
+            "allowedValues": [
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x5d",
+                "name": "left",
+                "value": "left"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x5f",
+                "name": "right",
+                "value": "right"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x60",
+                "name": "center",
+                "value": "center"
+              }
+            ],
+            "id": "0x5e",
+            "name": "Orientation",
+            "typeKind": "EnumType"
+          },
+          {
+            "__typename": "EnumType",
+            "allowedValues": [
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x58",
+                "name": "",
+                "value": "horizontal"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x59",
+                "name": "",
+                "value": "vertical"
+              }
+            ],
+            "id": "0x57",
+            "name": "Direction",
+            "typeKind": "EnumType"
+          }
+        ]
+      },
+      "typeKind": "InterfaceType"
+    },
+    "id": "0x48",
+    "name": "Divider",
+    "type": "AntDesignDivider"
+  }
+]

--- a/libs/backend/modules/atom/src/domain/data/GridCol.json
+++ b/libs/backend/modules/atom/src/domain/data/GridCol.json
@@ -1,0 +1,197 @@
+[
+  {
+    "__typename": "Atom",
+    "api": {
+      "__typename": "InterfaceType",
+      "id": "0x72",
+      "name": "GridCol API",
+      "typeGraph": {
+        "__typename": "TypeGraph",
+        "edges": [
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Flex layout style",
+              "id": "0x73",
+              "key": "flex",
+              "name": "Flex"
+            },
+            "kind": "Field",
+            "source": "0x72",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "The number of cells to offset Col from the left",
+              "id": "0x74",
+              "key": "offset",
+              "name": "Offset"
+            },
+            "kind": "Field",
+            "source": "0x72",
+            "target": "0x75"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Raster order",
+              "id": "0x76",
+              "key": "order",
+              "name": "Order"
+            },
+            "kind": "Field",
+            "source": "0x72",
+            "target": "0x75"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "The number of cells that raster is moved to the left",
+              "id": "0x77",
+              "key": "pull",
+              "name": "Pull"
+            },
+            "kind": "Field",
+            "source": "0x72",
+            "target": "0x75"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "The number of cells that raster is moved to the right",
+              "id": "0x78",
+              "key": "push",
+              "name": "Push"
+            },
+            "kind": "Field",
+            "source": "0x72",
+            "target": "0x75"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Raster number of cells to occupy, 0 corresponds to display: none",
+              "id": "0x79",
+              "key": "span",
+              "name": "Span"
+            },
+            "kind": "Field",
+            "source": "0x72",
+            "target": "0x75"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "screen < 576px and also default setting, could be a span value or an object containing above props",
+              "id": "0x7a",
+              "key": "xs",
+              "name": "Xs"
+            },
+            "kind": "Field",
+            "source": "0x72",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "screen ≥ 576px, could be a span value or an object containing above props",
+              "id": "0x7b",
+              "key": "sm",
+              "name": "Sm"
+            },
+            "kind": "Field",
+            "source": "0x72",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "screen ≥ 768px, could be a span value or an object containing above props",
+              "id": "0x7c",
+              "key": "md",
+              "name": "Md"
+            },
+            "kind": "Field",
+            "source": "0x72",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "screen ≥ 992px, could be a span value or an object containing above props",
+              "id": "0x7d",
+              "key": "lg",
+              "name": "Lg"
+            },
+            "kind": "Field",
+            "source": "0x72",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "screen ≥ 1200px, could be a span value or an object containing above props",
+              "id": "0x7e",
+              "key": "xl",
+              "name": "Xl"
+            },
+            "kind": "Field",
+            "source": "0x72",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "screen ≥ 1600px, could be a span value or an object containing above props",
+              "id": "0x7f",
+              "key": "xxl",
+              "name": "Xxl"
+            },
+            "kind": "Field",
+            "source": "0x72",
+            "target": "0x32"
+          }
+        ],
+        "vertices": [
+          {
+            "__typename": "InterfaceType",
+            "id": "0x72",
+            "name": "GridCol API",
+            "typeKind": "InterfaceType"
+          },
+          {
+            "__typename": "PrimitiveType",
+            "id": "0x32",
+            "name": "String",
+            "primitiveKind": "String",
+            "typeKind": "PrimitiveType"
+          },
+          {
+            "__typename": "PrimitiveType",
+            "id": "0x75",
+            "name": "Integer",
+            "primitiveKind": "Integer",
+            "typeKind": "PrimitiveType"
+          }
+        ]
+      },
+      "typeKind": "InterfaceType"
+    },
+    "id": "0x71",
+    "name": "GridCol",
+    "type": "AntDesignGridCol"
+  }
+]

--- a/libs/backend/modules/atom/src/domain/data/GridRow.json
+++ b/libs/backend/modules/atom/src/domain/data/GridRow.json
@@ -1,0 +1,157 @@
+[
+  {
+    "__typename": "Atom",
+    "api": {
+      "__typename": "InterfaceType",
+      "id": "0x62",
+      "name": "GridRow API",
+      "typeGraph": {
+        "__typename": "TypeGraph",
+        "edges": [
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Vertical alignment",
+              "id": "0x63",
+              "key": "align",
+              "name": "Align"
+            },
+            "kind": "Field",
+            "source": "0x62",
+            "target": "0x67"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Spacing between grids, could be a number or a object like { xs: 8, sm: 16, md: 24}. Or you can use array to make horizontal and vertical spacing work at the same time [horizontal, vertical]\t",
+              "id": "0x64",
+              "key": "gutter",
+              "name": "Gutter"
+            },
+            "kind": "Field",
+            "source": "0x62",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Horizontal arrangement",
+              "id": "0x65",
+              "key": "justify",
+              "name": "justify"
+            },
+            "kind": "Field",
+            "source": "0x62",
+            "target": "0x6f"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Auto wrap line",
+              "id": "0x66",
+              "key": "wrap",
+              "name": "wrap"
+            },
+            "kind": "Field",
+            "source": "0x62",
+            "target": "0x34"
+          }
+        ],
+        "vertices": [
+          {
+            "__typename": "InterfaceType",
+            "id": "0x62",
+            "name": "GridRow API",
+            "typeKind": "InterfaceType"
+          },
+          {
+            "__typename": "EnumType",
+            "allowedValues": [
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x68",
+                "name": "top",
+                "value": "top"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x69",
+                "name": "middle",
+                "value": "middle"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x6a",
+                "name": "bottom",
+                "value": "bottom"
+              }
+            ],
+            "id": "0x67",
+            "name": "VerticalAlignment",
+            "typeKind": "EnumType"
+          },
+          {
+            "__typename": "PrimitiveType",
+            "id": "0x32",
+            "name": "String",
+            "primitiveKind": "String",
+            "typeKind": "PrimitiveType"
+          },
+          {
+            "__typename": "EnumType",
+            "allowedValues": [
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x6b",
+                "name": "end",
+                "value": "end"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x6c",
+                "name": "center",
+                "value": "center"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x6d",
+                "name": "space-around",
+                "value": "space-around"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x6e",
+                "name": "space-between",
+                "value": "space-between"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x70",
+                "name": "start",
+                "value": "start"
+              }
+            ],
+            "id": "0x6f",
+            "name": "HorizontalArrangement",
+            "typeKind": "EnumType"
+          },
+          {
+            "__typename": "PrimitiveType",
+            "id": "0x34",
+            "name": "Boolean",
+            "primitiveKind": "Boolean",
+            "typeKind": "PrimitiveType"
+          }
+        ]
+      },
+      "typeKind": "InterfaceType"
+    },
+    "id": "0x61",
+    "name": "GridRow",
+    "type": "AntDesignGridRow"
+  }
+]

--- a/libs/backend/modules/atom/src/domain/data/Layout.json
+++ b/libs/backend/modules/atom/src/domain/data/Layout.json
@@ -1,0 +1,80 @@
+[
+  {
+    "__typename": "Atom",
+    "api": {
+      "__typename": "InterfaceType",
+      "id": "0x23",
+      "name": "Layout API",
+      "typeGraph": {
+        "__typename": "TypeGraph",
+        "edges": [
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Container className",
+              "id": "0x24",
+              "key": "className",
+              "name": "ClassName"
+            },
+            "kind": "Field",
+            "source": "0x23",
+            "target": "0x8"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Whther contain Sider in children, don't have to assign it normally. Useful in ssr avoid style flickering",
+              "id": "0x25",
+              "key": "hasSider",
+              "name": "HasSider"
+            },
+            "kind": "Field",
+            "source": "0x23",
+            "target": "0x9"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "To customize the styles",
+              "id": "0x26",
+              "key": "style",
+              "name": "Style"
+            },
+            "kind": "Field",
+            "source": "0x23",
+            "target": "0x8"
+          }
+        ],
+        "vertices": [
+          {
+            "__typename": "InterfaceType",
+            "id": "0x23",
+            "name": "Layout API",
+            "typeKind": "InterfaceType"
+          },
+          {
+            "__typename": "PrimitiveType",
+            "id": "0x8",
+            "name": "String",
+            "primitiveKind": "String",
+            "typeKind": "PrimitiveType"
+          },
+          {
+            "__typename": "PrimitiveType",
+            "id": "0x9",
+            "name": "Boolean",
+            "primitiveKind": "Boolean",
+            "typeKind": "PrimitiveType"
+          }
+        ]
+      },
+      "typeKind": "InterfaceType"
+    },
+    "id": "0x22",
+    "name": "Layout",
+    "type": "AntDesignLayout"
+  }
+]

--- a/libs/backend/modules/atom/src/domain/data/LayoutSider.json
+++ b/libs/backend/modules/atom/src/domain/data/LayoutSider.json
@@ -1,0 +1,306 @@
+[
+  {
+    "__typename": "Atom",
+    "api": {
+      "__typename": "InterfaceType",
+      "id": "0x81",
+      "name": "LayoutSider API",
+      "typeGraph": {
+        "__typename": "TypeGraph",
+        "edges": [
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Breakpoints of the responsive layout",
+              "id": "0x82",
+              "key": "breakpoint",
+              "name": "breakpoint"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x94"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Container className",
+              "id": "0x83",
+              "key": "className",
+              "name": "ClassName"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "To set the current status",
+              "id": "0x84",
+              "key": "collapsed",
+              "name": "Collapsed"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x34"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Width of the collapsed sidebar, by setting to 0 a special trigger will appear",
+              "id": "0x85",
+              "key": "collapsedWidth",
+              "name": "Collapsed Width"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x75"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Whether can be collapsed",
+              "id": "0x86",
+              "key": "collapsible",
+              "name": "Collapsible"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x34"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "To set the initial status",
+              "id": "0x87",
+              "key": "defaultCollapsed",
+              "name": "Default Collapsed"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x34"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Reverse direction of arrow, for a sider that expands from the right\t",
+              "id": "0x88",
+              "key": "reverseArrow",
+              "name": "Reverse Arrow"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x34"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "To customize the styles",
+              "id": "0x89",
+              "key": "style",
+              "name": "Style"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Color theme of the sidebar",
+              "id": "0x8a",
+              "key": "theme",
+              "name": "Theme"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x91"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Specify the customized trigger, set to null to hide the trigger",
+              "id": "0x8b",
+              "key": "trigger",
+              "name": "Trigger"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x2a"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Width of the sidebar",
+              "id": "0x8c",
+              "key": "width",
+              "name": "Width"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "To customize the styles of the special trigger that appears when collapsedWidth is 0",
+              "id": "0x8d",
+              "key": "zeroWidthTriggerStyle",
+              "name": "Zero Width Trigger Style"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "The callback function, executed when breakpoints changed",
+              "id": "0x8e",
+              "key": "onBreakpoint",
+              "name": "On Breakpoint"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x33"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "The callback function, executed by clicking the trigger or activating the responsive layout",
+              "id": "0x8f",
+              "key": "onCollapse",
+              "name": "On Collapse"
+            },
+            "kind": "Field",
+            "source": "0x81",
+            "target": "0x33"
+          }
+        ],
+        "vertices": [
+          {
+            "__typename": "InterfaceType",
+            "id": "0x81",
+            "name": "LayoutSider API",
+            "typeKind": "InterfaceType"
+          },
+          {
+            "__typename": "EnumType",
+            "allowedValues": [
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x95",
+                "name": "xs",
+                "value": "xs"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x96",
+                "name": "sm",
+                "value": "sm"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x97",
+                "name": "md",
+                "value": "md"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x98",
+                "name": "lg",
+                "value": "lg"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x99",
+                "name": "xl",
+                "value": "xl"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x9a",
+                "name": "xxl",
+                "value": "xxl"
+              }
+            ],
+            "id": "0x94",
+            "name": "Breakpoint",
+            "typeKind": "EnumType"
+          },
+          {
+            "__typename": "PrimitiveType",
+            "id": "0x32",
+            "name": "String",
+            "primitiveKind": "String",
+            "typeKind": "PrimitiveType"
+          },
+          {
+            "__typename": "PrimitiveType",
+            "id": "0x34",
+            "name": "Boolean",
+            "primitiveKind": "Boolean",
+            "typeKind": "PrimitiveType"
+          },
+          {
+            "__typename": "PrimitiveType",
+            "id": "0x75",
+            "name": "Integer",
+            "primitiveKind": "Integer",
+            "typeKind": "PrimitiveType"
+          },
+          {
+            "__typename": "EnumType",
+            "allowedValues": [
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x92",
+                "name": "light",
+                "value": "light"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x93",
+                "name": "dark",
+                "value": "dark"
+              }
+            ],
+            "id": "0x91",
+            "name": "LayoutSiderTheme",
+            "typeKind": "EnumType"
+          },
+          {
+            "__typename": "ComponentType",
+            "id": "0x2a",
+            "name": "Component",
+            "typeKind": "ComponentType"
+          },
+          {
+            "__typename": "LambdaType",
+            "id": "0x33",
+            "name": "Lambda",
+            "typeKind": "LambdaType"
+          }
+        ]
+      },
+      "typeKind": "InterfaceType"
+    },
+    "id": "0x80",
+    "name": "LayoutSider",
+    "type": "AntDesignLayoutSider"
+  }
+]

--- a/libs/backend/modules/atom/src/domain/data/Space.json
+++ b/libs/backend/modules/atom/src/domain/data/Space.json
@@ -1,0 +1,170 @@
+[
+  {
+    "__typename": "Atom",
+    "api": {
+      "__typename": "InterfaceType",
+      "id": "0x9c",
+      "name": "Space API",
+      "typeGraph": {
+        "__typename": "TypeGraph",
+        "edges": [
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Align items",
+              "id": "0x9d",
+              "key": "align",
+              "name": "Align"
+            },
+            "kind": "Field",
+            "source": "0x9c",
+            "target": "0xa3"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "The space direction",
+              "id": "0x9e",
+              "key": "direction",
+              "name": "Direction"
+            },
+            "kind": "Field",
+            "source": "0x9c",
+            "target": "0x5e"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "The space size",
+              "id": "0x9f",
+              "key": "size",
+              "name": "Size"
+            },
+            "kind": "Field",
+            "source": "0x9c",
+            "target": "0x32"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Set split",
+              "id": "0xa0",
+              "key": "split",
+              "name": "Split"
+            },
+            "kind": "Field",
+            "source": "0x9c",
+            "target": "0x2a"
+          },
+          {
+            "__typename": "TypeEdge",
+            "field": {
+              "__typename": "Field",
+              "description": "Auto wrap line, when horizontal effective",
+              "id": "0xa1",
+              "key": "wrap",
+              "name": "Wrap"
+            },
+            "kind": "Field",
+            "source": "0x9c",
+            "target": "0x34"
+          }
+        ],
+        "vertices": [
+          {
+            "__typename": "InterfaceType",
+            "id": "0x9c",
+            "name": "Space API",
+            "typeKind": "InterfaceType"
+          },
+          {
+            "__typename": "EnumType",
+            "allowedValues": [
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0xa2",
+                "name": "baseline",
+                "value": "baseline"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0xa4",
+                "name": "start",
+                "value": "start"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0xa5",
+                "name": "end",
+                "value": "end"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0xa6",
+                "name": "center",
+                "value": "center"
+              }
+            ],
+            "id": "0xa3",
+            "name": "SpaceAlign",
+            "typeKind": "EnumType"
+          },
+          {
+            "__typename": "EnumType",
+            "allowedValues": [
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x5d",
+                "name": "left",
+                "value": "left"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x5f",
+                "name": "right",
+                "value": "right"
+              },
+              {
+                "__typename": "EnumTypeValue",
+                "id": "0x60",
+                "name": "center",
+                "value": "center"
+              }
+            ],
+            "id": "0x5e",
+            "name": "Orientation",
+            "typeKind": "EnumType"
+          },
+          {
+            "__typename": "PrimitiveType",
+            "id": "0x32",
+            "name": "String",
+            "primitiveKind": "String",
+            "typeKind": "PrimitiveType"
+          },
+          {
+            "__typename": "ComponentType",
+            "id": "0x2a",
+            "name": "Component",
+            "typeKind": "ComponentType"
+          },
+          {
+            "__typename": "PrimitiveType",
+            "id": "0x34",
+            "name": "Boolean",
+            "primitiveKind": "Boolean",
+            "typeKind": "PrimitiveType"
+          }
+        ]
+      },
+      "typeKind": "InterfaceType"
+    },
+    "id": "0x9b",
+    "name": "Space",
+    "type": "AntDesignSpace"
+  }
+]


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Current Behavior

<!-- This is the behavior we have today -->

## Expected Behavior

add encoded props for layout components

<img width="355" alt="Screen Shot 2021-09-18 at 10 04 28 AM" src="https://user-images.githubusercontent.com/81953075/133891481-2a4612c8-5878-4391-bb86-b8f48534508e.png">


## Related Issue(s)


<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #1094 
