### PR TITLE
feat: persisted recoil state, graphql variables and bug fixes

### DIFF
--- a/libs/backend/modules/element/src/use-cases/element/get-element/tests/get-element.api.graphql
+++ b/libs/backend/modules/element/src/use-cases/element/get-element/tests/get-element.api.graphql
@@ -26,6 +26,7 @@ query TestGetElement($input: GetElementInput!) {
         ... on RecoilStateHookConfig {
           defaultValue
           stateKey
+          persisted
           __typename
         }
         ... on GraphqlHookConfig {

--- a/libs/backend/modules/element/src/use-cases/element/get-element/tests/get-element.api.graphql.gen.ts
+++ b/libs/backend/modules/element/src/use-cases/element/get-element/tests/get-element.api.graphql.gen.ts
@@ -8,7 +8,7 @@ export type TestGetElementQueryVariables = Types.Exact<{
 }>;
 
 
-export type TestGetElementQuery = { getElement?: Types.Maybe<{ id: string, name: string, css?: Types.Maybe<string>, props: string, renderForEachPropKey?: Types.Maybe<string>, renderIfPropKey?: Types.Maybe<string>, atom?: Types.Maybe<{ id: string, name: string, type: Types.AtomType }>, hooks: Array<{ id: string, type: Types.HookType, config: { __typename: 'GraphqlHookConfig', dataKey?: Types.Maybe<string>, graphqlBody: string, graphqlUrl: string } | { __typename: 'QueryHookConfig', body?: Types.Maybe<string>, lambdaId?: Types.Maybe<string>, method?: Types.Maybe<Types.QueryMethod>, queryKey: string, url?: Types.Maybe<string> } | { __typename: 'RecoilStateHookConfig', defaultValue?: Types.Maybe<string>, stateKey: string } | {} }>, propMapBindings: Array<{ id: string, sourceKey: string, targetElementId?: Types.Maybe<string>, targetKey: string }> }> };
+export type TestGetElementQuery = { getElement?: Types.Maybe<{ id: string, name: string, css?: Types.Maybe<string>, props: string, renderForEachPropKey?: Types.Maybe<string>, renderIfPropKey?: Types.Maybe<string>, atom?: Types.Maybe<{ id: string, name: string, type: Types.AtomType }>, hooks: Array<{ id: string, type: Types.HookType, config: { __typename: 'GraphqlHookConfig', dataKey?: Types.Maybe<string>, graphqlBody: string, graphqlUrl: string } | { __typename: 'QueryHookConfig', body?: Types.Maybe<string>, lambdaId?: Types.Maybe<string>, method?: Types.Maybe<Types.QueryMethod>, queryKey: string, url?: Types.Maybe<string> } | { __typename: 'RecoilStateHookConfig', defaultValue?: Types.Maybe<string>, stateKey: string, persisted: Types.PersistenceType } | {} }>, propMapBindings: Array<{ id: string, sourceKey: string, targetElementId?: Types.Maybe<string>, targetKey: string }> }> };
 
 
 export const TestGetElementGql = gql`
@@ -40,6 +40,7 @@ export const TestGetElementGql = gql`
         ... on RecoilStateHookConfig {
           defaultValue
           stateKey
+          persisted
           __typename
         }
         ... on GraphqlHookConfig {

--- a/libs/backend/modules/element/src/use-cases/element/hooks/add-hook-to-element/config-inputs/recoil-state-hook-config.input.ts
+++ b/libs/backend/modules/element/src/use-cases/element/hooks/add-hook-to-element/config-inputs/recoil-state-hook-config.input.ts
@@ -1,4 +1,5 @@
 import { RecoilStateHookConfig } from '@codelab/backend/modules/hook'
+import { PersistenceType } from '@codelab/shared/abstract/core'
 import { Field, InputType } from '@nestjs/graphql'
 
 @InputType()
@@ -8,4 +9,7 @@ export class RecoilStateHookConfigInput implements RecoilStateHookConfig {
 
   @Field(() => String, { nullable: true })
   declare defaultValue?: string
+
+  @Field(() => PersistenceType)
+  declare persisted: PersistenceType
 }

--- a/libs/backend/modules/element/src/use-cases/element/hooks/add-hook-to-element/tests/add-hook-to-element.i.spec.ts
+++ b/libs/backend/modules/element/src/use-cases/element/hooks/add-hook-to-element/tests/add-hook-to-element.i.spec.ts
@@ -1,6 +1,11 @@
 import { domainRequest } from '@codelab/backend/infra'
 import { setupTestModule, teardownTestModule } from '@codelab/backend/nestjs'
-import { HookType, QueryMethod, Role } from '@codelab/shared/abstract/core'
+import {
+  HookType,
+  PersistenceType,
+  QueryMethod,
+  Role,
+} from '@codelab/shared/abstract/core'
 import { INestApplication } from '@nestjs/common'
 import { ElementModule } from '../../../../../element.module'
 import { CreateElementInput } from '../../../create-element'
@@ -90,6 +95,7 @@ describe('AddHookToElementUseCase', () => {
       recoilStateHook: {
         stateKey: 'myState',
         defaultValue: 'true',
+        persisted: PersistenceType.NotPersisted,
       },
     }
 

--- a/libs/backend/modules/hook/src/application/hook-config/recoil-state-hook-config.model.ts
+++ b/libs/backend/modules/hook/src/application/hook-config/recoil-state-hook-config.model.ts
@@ -1,5 +1,10 @@
-import { Field, ObjectType } from '@nestjs/graphql'
+import { PersistenceType } from '@codelab/shared/abstract/core'
+import { Field, ObjectType, registerEnumType } from '@nestjs/graphql'
 import { RecoilStateHookConfig } from '../../domain'
+
+registerEnumType(PersistenceType, {
+  name: 'PersistenceType',
+})
 
 @ObjectType('RecoilStateHookConfig')
 export class RecoilStateHookConfigModel implements RecoilStateHookConfig {
@@ -9,8 +14,16 @@ export class RecoilStateHookConfigModel implements RecoilStateHookConfig {
   @Field({ nullable: true })
   defaultValue?: string
 
-  constructor({ stateKey, defaultValue }: RecoilStateHookConfigModel) {
+  @Field(() => PersistenceType)
+  declare persisted: PersistenceType
+
+  constructor({
+    stateKey,
+    defaultValue,
+    persisted,
+  }: RecoilStateHookConfigModel) {
     this.stateKey = stateKey
     this.defaultValue = defaultValue
+    this.persisted = persisted
   }
 }

--- a/libs/backend/modules/hook/src/domain/hook-config/recoil-state-hook-config.schema.ts
+++ b/libs/backend/modules/hook/src/domain/hook-config/recoil-state-hook-config.schema.ts
@@ -1,12 +1,17 @@
+import { PersistenceType } from '@codelab/shared/abstract/core'
 import { z } from 'zod'
 
 export type RecoilStateHookConfig = {
   stateKey: string
   defaultValue?: string
+  persisted?: PersistenceType
 }
 
 export const recoilStateHookConfigSchema: z.ZodSchema<RecoilStateHookConfig> =
   z.object({
     stateKey: z.string().nonempty(),
     defaultValue: z.string().optional(),
+    persisted: z
+      .nativeEnum(PersistenceType)
+      .default(PersistenceType.NotPersisted),
   })

--- a/libs/frontend/modules/builder/src/meta-pane/MetaPaneBuilderComponent.tsx
+++ b/libs/frontend/modules/builder/src/meta-pane/MetaPaneBuilderComponent.tsx
@@ -1,6 +1,7 @@
 import {
   ComponentContext,
   MoveComponentElementForm,
+  refetchGetComponentElementsQuery,
 } from '@codelab/frontend/modules/component'
 import {
   DeleteElementButton,
@@ -14,7 +15,7 @@ import { usePropCompletion } from '../containers/usePropCompletion'
 import { MetaPaneBuilder } from './MetaPaneBuilder'
 
 export const MetaPaneBuilderComponent = () => {
-  const { tree } = useContext(ComponentContext)
+  const { tree, component } = useContext(ComponentContext)
   const { providePropCompletion } = usePropCompletion()
 
   return (
@@ -31,6 +32,11 @@ export const MetaPaneBuilderComponent = () => {
               providePropCompletion={(value) =>
                 providePropCompletion(value, element.id)
               }
+              refetchQueries={[
+                refetchGetComponentElementsQuery({
+                  input: { componentId: component.id },
+                }),
+              ]}
             />
 
             <MoveComponentElementForm

--- a/libs/frontend/modules/builder/src/meta-pane/MetaPaneBuilderPage.tsx
+++ b/libs/frontend/modules/builder/src/meta-pane/MetaPaneBuilderPage.tsx
@@ -5,6 +5,7 @@ import {
 import {
   MovePageElementForm,
   PageContext,
+  refetchGetPageQuery,
 } from '@codelab/frontend/modules/page'
 import { SelectElementProvider } from '@codelab/frontend/modules/type'
 import React, { useContext } from 'react'
@@ -12,7 +13,7 @@ import { usePropCompletion } from '../containers/usePropCompletion'
 import { MetaPaneBuilder } from './MetaPaneBuilder'
 
 export const MetaPaneBuilderPage = () => {
-  const { tree } = useContext(PageContext)
+  const { tree, pageId } = useContext(PageContext)
   const { providePropCompletion } = usePropCompletion()
 
   return (
@@ -29,6 +30,7 @@ export const MetaPaneBuilderPage = () => {
               providePropCompletion={(value) =>
                 providePropCompletion(value, element.id)
               }
+              refetchQueries={[refetchGetPageQuery({ input: { pageId } })]}
             />
 
             <MovePageElementForm

--- a/libs/frontend/modules/builder/src/renderer/Renderer.tsx
+++ b/libs/frontend/modules/builder/src/renderer/Renderer.tsx
@@ -36,11 +36,13 @@ export const Renderer = React.memo<RendererProps>(
     const rendered = (
       <ErrorBoundary>
         <RenderProvider<ElementTreeGraphql> context={context}>
-          {context.renderFactory(root, {
-            ...(context ?? {}),
-            inspect: false,
-            tree,
-          })}
+          <div id="render-root">
+            {context.renderFactory(root, {
+              ...(context ?? {}),
+              inspect: false,
+              tree,
+            })}
+          </div>
         </RenderProvider>
       </ErrorBoundary>
     )

--- a/libs/frontend/modules/builder/src/renderer/handlers/renderElement.tsx
+++ b/libs/frontend/modules/builder/src/renderer/handlers/renderElement.tsx
@@ -106,6 +106,7 @@ const hookPipe: RenderPipeFactory = (next) => (element, context, props) => {
       <HookElementWrapper
         key={`${props.key ?? element.id}-${element.hooks.length}`}
         hooks={element.hooks}
+        inputProps={props}
         renderChildren={(hookProps) => {
           return next(element, context, mergeProps(props, hookProps))
         }}
@@ -360,9 +361,9 @@ const propsPipeline = compose(
 // (2).Prop transformers
 const propModifiersPipeline = compose(
   hookPipe,
-  loopingRenderPipe,
-  propMapBindingsPipe,
   propTransformationJsPipe,
+  loopingRenderPipe,
+  propMapBindingsPipe, // We want the propMapBindings to be last, so that we can pass any transformed/modified props down
 )
 
 // (3). All the pipes that output ReactElements

--- a/libs/frontend/modules/builder/src/renderer/hooks/HookElementWrapper.tsx
+++ b/libs/frontend/modules/builder/src/renderer/hooks/HookElementWrapper.tsx
@@ -4,6 +4,7 @@ import { useHookFactory } from './useHookFactory'
 
 export interface HookElementWrapperProps {
   children?: never
+  inputProps?: Record<string, any>
   hooks: Array<HookFragment>
   renderChildren: (hookProps: Record<string, any>) => React.ReactNode
 }
@@ -16,9 +17,10 @@ export interface HookElementWrapperProps {
  */
 export const HookElementWrapper = ({
   hooks,
+  inputProps,
   renderChildren,
 }: HookElementWrapperProps) => {
-  const hookProps = useHookFactory(hooks)
+  const hookProps = useHookFactory(hooks, inputProps)
 
   if (!renderChildren) {
     return null

--- a/libs/frontend/modules/builder/src/renderer/hooks/HookHandler.ts
+++ b/libs/frontend/modules/builder/src/renderer/hooks/HookHandler.ts
@@ -1,3 +1,4 @@
 export type HookHandler = (
   config: any,
+  props?: Record<string, any>,
 ) => Record<string, any> | void | undefined

--- a/libs/frontend/modules/builder/src/renderer/hooks/handlers/useGraphqlMutationHook.ts
+++ b/libs/frontend/modules/builder/src/renderer/hooks/handlers/useGraphqlMutationHook.ts
@@ -8,12 +8,14 @@ import { apolloClient } from '../utils/apolloClient'
 
 export const useGraphqlMutationHook: HookHandler = (
   config: GraphqlHookConfigFragment,
+  inputProps,
 ) => {
   const [mutate, { data, error, called, loading }] = useMutation(
     gql(config.graphqlBody),
     {
       client: apolloClient,
       context: { uri: config.graphqlUrl },
+      variables: inputProps ?? undefined,
     },
   )
 

--- a/libs/frontend/modules/builder/src/renderer/hooks/handlers/useGraphqlQueryHook.ts
+++ b/libs/frontend/modules/builder/src/renderer/hooks/handlers/useGraphqlQueryHook.ts
@@ -7,20 +7,15 @@ import { apolloClient } from '../utils/apolloClient'
 
 export const useGraphqlQueryHook: HookHandler = (
   config: GraphqlHookConfigFragment,
+  inputProps,
 ) => {
   // Only get serializable properties, weird errors happen if we include other things like client
-  const {
-    data,
-    error,
-    called,
-    loading,
-    previousData,
-    networkStatus,
-    variables,
-  } = useQuery(gql(config.graphqlBody), {
-    client: apolloClient,
-    context: { uri: config.graphqlUrl },
-  })
+  const { data, error, called, loading, previousData, networkStatus } =
+    useQuery(gql(config.graphqlBody), {
+      client: apolloClient,
+      variables: inputProps ?? undefined,
+      context: { uri: config.graphqlUrl },
+    })
 
   const res = {
     data,
@@ -29,7 +24,6 @@ export const useGraphqlQueryHook: HookHandler = (
     loading,
     previousData,
     networkStatus,
-    variables,
   }
 
   if (config.dataKey && res.data && res.data[config.dataKey]) {

--- a/libs/frontend/modules/builder/src/renderer/hooks/handlers/useRecoilStateHook.ts
+++ b/libs/frontend/modules/builder/src/renderer/hooks/handlers/useRecoilStateHook.ts
@@ -1,8 +1,9 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import { RecoilStateHookConfigFragment } from '@codelab/frontend/modules/element'
+import { PersistenceType } from '@codelab/shared/codegen/graphql'
 import { capitalizeFirstLetter } from '@codelab/shared/utils'
-import { useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { atomFamily, useRecoilState } from 'recoil'
 import { HookHandler } from '../HookHandler'
 
@@ -18,22 +19,79 @@ export const useRecoilStateHook: HookHandler = (
     return undefined
   }
 
+  // used to set the default value on first render
+  const [isInitialized, setIsInitialized] = useState(false)
+  const storageKey = `codelab_state_${config.stateKey}`
+
   const [state, setState] = useRecoilState<any>(
     stateAtomFamily(config.stateKey),
   )
 
-  useEffect(() => {
-    if (typeof config.defaultValue !== 'undefined') {
-      let defaultValue: any
+  // Stores the value in the configured storage
+  const store = useCallback(
+    (value: any) => {
+      if (
+        config.persisted === PersistenceType.SessionStorage ||
+        config.persisted === PersistenceType.LocalStorage
+      ) {
+        try {
+          const storage =
+            config.persisted === PersistenceType.LocalStorage
+              ? localStorage
+              : sessionStorage
 
-      try {
-        if (config.defaultValue) {
-          defaultValue = JSON.parse(config.defaultValue)
-        } else {
+          console.log(JSON.stringify(value))
+          storage.setItem(storageKey, JSON.stringify(value))
+        } catch (e) {
+          console.error(
+            'Error while persisting state',
+            config.stateKey,
+            config.persisted,
+            e,
+          )
+        }
+      }
+    },
+    [config.persisted, storageKey],
+  )
+
+  useEffect(() => {
+    if (!isInitialized) {
+      // Set the default value on mount
+      let defaultValue: any | null
+
+      if (
+        config.persisted === PersistenceType.SessionStorage ||
+        config.persisted === PersistenceType.LocalStorage
+      ) {
+        const storage =
+          config.persisted === PersistenceType.LocalStorage
+            ? localStorage
+            : sessionStorage
+
+        try {
+          const item = storage.getItem(storageKey)
+          defaultValue = item ? JSON.parse(item) : null
+        } catch (e) {
+          console.error(
+            'Error while loading persisted state value',
+            config.stateKey,
+            config.persisted,
+            e,
+          )
+        }
+      }
+
+      if (!defaultValue && typeof config.defaultValue !== 'undefined') {
+        try {
+          if (config.defaultValue) {
+            defaultValue = JSON.parse(config.defaultValue)
+          } else {
+            defaultValue = config.defaultValue
+          }
+        } catch (e) {
           defaultValue = config.defaultValue
         }
-      } catch (e) {
-        defaultValue = config.defaultValue
       }
 
       setState((s: any) => {
@@ -43,8 +101,15 @@ export const useRecoilStateHook: HookHandler = (
 
         return defaultValue
       })
+
+      setIsInitialized(true)
     }
-  }, [setState, config.defaultValue])
+  }, [setState])
+
+  // Store the vlaue whenever it changes, that way we need to set the storage config on only 1 hook
+  useEffect(() => {
+    store(state)
+  }, [store, state])
 
   return {
     [config.stateKey]: state,

--- a/libs/frontend/modules/builder/src/renderer/hooks/useHookFactory.ts
+++ b/libs/frontend/modules/builder/src/renderer/hooks/useHookFactory.ts
@@ -9,38 +9,51 @@ import { useQueryPagesHook } from './handlers/useQueryPages'
 import { useRecoilStateHook } from './handlers/useRecoilStateHook'
 import { HookHandler } from './HookHandler'
 
-export const useHookFactory = (hooks: Array<HookFragment>) => {
+export const useHookFactory = (
+  hooks: Array<HookFragment>,
+  inputProps?: Record<string, any>,
+) => {
   return hooks.reduce<Record<string, any>>((queryProps, hook) => {
-    const hookData = getHookData(hook) ?? {}
+    const hookData = getHookData(hook, inputProps) ?? {}
 
     return Object.assign(queryProps, hookData)
   }, {})
 }
 
-const getHookData: HookHandler = ({ config, type }: HookFragment) => {
+const getHookData: HookHandler = (
+  { config, type }: HookFragment,
+  inputProps?: Record<string, any>,
+) => {
+  let handler: HookHandler
+
   switch (type) {
-    case HookType.Query: {
-      return useQueryHook(config)
-    }
+    case HookType.Query:
+      handler = useQueryHook
+      break
 
-    case HookType.GraphqlQuery: {
-      return useGraphqlQueryHook(config)
-    }
+    case HookType.GraphqlQuery:
+      handler = useGraphqlQueryHook
+      break
 
-    case HookType.GraphqlMutation: {
-      return useGraphqlMutationHook(config)
-    }
+    case HookType.GraphqlMutation:
+      handler = useGraphqlMutationHook
+      break
 
-    case HookType.RecoilState: {
-      return useRecoilStateHook(config)
-    }
+    case HookType.RecoilState:
+      handler = useRecoilStateHook
+      break
 
-    case HookType.QueryPage: {
-      return useQueryPageHook(config)
-    }
+    case HookType.QueryPage:
+      handler = useQueryPageHook
+      break
 
-    case HookType.QueryPages: {
-      return useQueryPagesHook(config)
-    }
+    case HookType.QueryPages:
+      handler = useQueryPagesHook
+      break
+
+    default:
+      return undefined
   }
+
+  return handler(config, inputProps)
 }

--- a/libs/frontend/modules/builder/src/renderer/reactComponentFactory.tsx
+++ b/libs/frontend/modules/builder/src/renderer/reactComponentFactory.tsx
@@ -42,7 +42,7 @@ export const elementsPropTransformers: Partial<
   }),
   [AtomType.AntDesignModal]: ({ props }) => ({
     ...props,
-    getContainer: '#Builder',
+    getContainer: '#render-root',
   }),
   [AtomType.ReactFragment]: ({ props: { key } }) => ({ key }), // Do not pass in any props for fragments, except key, because it creates an error
   [AtomType.HtmlImage]: (input) => ({ src: '', alt: '' }),

--- a/libs/frontend/modules/element/src/graphql/HookConfig.fragment.graphql
+++ b/libs/frontend/modules/element/src/graphql/HookConfig.fragment.graphql
@@ -15,6 +15,7 @@ fragment GraphqlHookConfig on GraphqlHookConfig {
 fragment RecoilStateHookConfig on RecoilStateHookConfig {
   defaultValue
   stateKey
+  persisted
 }
 
 fragment QueryPagesHookConfig on QueryPagesHookConfig {

--- a/libs/frontend/modules/element/src/graphql/HookConfig.fragment.graphql.gen.ts
+++ b/libs/frontend/modules/element/src/graphql/HookConfig.fragment.graphql.gen.ts
@@ -5,7 +5,7 @@ export type QueryHookConfigFragment = { body?: Types.Maybe<string>, method?: Typ
 
 export type GraphqlHookConfigFragment = { dataKey?: Types.Maybe<string>, graphqlBody: string, graphqlUrl: string };
 
-export type RecoilStateHookConfigFragment = { defaultValue?: Types.Maybe<string>, stateKey: string };
+export type RecoilStateHookConfigFragment = { defaultValue?: Types.Maybe<string>, stateKey: string, persisted: Types.PersistenceType };
 
 export type QueryPagesHookConfigFragment = { appId: string };
 
@@ -58,6 +58,7 @@ export const RecoilStateHookConfigFragmentDoc = gql`
     fragment RecoilStateHookConfig on RecoilStateHookConfig {
   defaultValue
   stateKey
+  persisted
 }
     `;
 export const QueryPagesHookConfigFragmentDoc = gql`

--- a/libs/frontend/modules/element/src/graphql/HookConfig.fragment.web.graphql.gen.ts
+++ b/libs/frontend/modules/element/src/graphql/HookConfig.fragment.web.graphql.gen.ts
@@ -5,7 +5,7 @@ export type QueryHookConfigFragment = { body?: Types.Maybe<string>, method?: Typ
 
 export type GraphqlHookConfigFragment = { dataKey?: Types.Maybe<string>, graphqlBody: string, graphqlUrl: string };
 
-export type RecoilStateHookConfigFragment = { defaultValue?: Types.Maybe<string>, stateKey: string };
+export type RecoilStateHookConfigFragment = { defaultValue?: Types.Maybe<string>, stateKey: string, persisted: Types.PersistenceType };
 
 export type QueryPagesHookConfigFragment = { appId: string };
 
@@ -58,6 +58,7 @@ export const RecoilStateHookConfigFragmentDoc = gql`
     fragment RecoilStateHookConfig on RecoilStateHookConfig {
   defaultValue
   stateKey
+  persisted
 }
     `;
 export const QueryPagesHookConfigFragmentDoc = gql`

--- a/libs/frontend/modules/element/src/use-cases/hooks/add-hook-to-element/AddHookToElementForm.tsx
+++ b/libs/frontend/modules/element/src/use-cases/hooks/add-hook-to-element/AddHookToElementForm.tsx
@@ -196,7 +196,9 @@ export const AddHookToElementForm = ({
 
       {/* Recoil state fields */}
       <DisplayIfType type={HookType.RecoilState}>
-        <AutoFields fields={['recoilStateHook.stateKey']} />
+        <AutoFields
+          fields={['recoilStateHook.stateKey', 'recoilStateHook.persisted']}
+        />
         <DefaultValueField name="recoilStateHook.defaultValue" />
       </DisplayIfType>
     </FormUniforms>

--- a/libs/frontend/modules/element/src/use-cases/hooks/add-hook-to-element/addHookToElementSchema.ts
+++ b/libs/frontend/modules/element/src/use-cases/hooks/add-hook-to-element/addHookToElementSchema.ts
@@ -1,4 +1,8 @@
-import { HookType, QueryMethod } from '@codelab/shared/abstract/core'
+import {
+  HookType,
+  PersistenceType,
+  QueryMethod,
+} from '@codelab/shared/abstract/core'
 import { JSONSchemaType } from 'ajv'
 import { AddHookToElementMutationVariables } from './AddHookToElement.web.graphql.gen'
 
@@ -125,6 +129,11 @@ export const addHookToElementSchema: JSONSchemaType<AddHookToElementSchema> = {
         },
         defaultValue: {
           type: 'string',
+        },
+        persisted: {
+          type: 'string',
+          enum: Object.values(PersistenceType),
+          default: PersistenceType.NotPersisted,
         },
       },
       required: ['stateKey'],

--- a/libs/frontend/modules/element/src/use-cases/update-element/UpdateElementForm.tsx
+++ b/libs/frontend/modules/element/src/use-cases/update-element/UpdateElementForm.tsx
@@ -1,3 +1,4 @@
+import { MutationHookOptions } from '@apollo/client'
 import { SelectAtom, SelectComponent } from '@codelab/frontend/modules/type'
 import { createNotificationHandler } from '@codelab/frontend/shared/utils'
 import {
@@ -20,6 +21,7 @@ type UpdateElementFormInternalProps =
     element: ElementFragment
     providePropCompletion?: (searchValue: string) => Array<string>
     loadingStateKey?: string
+    refetchQueries: Required<MutationHookOptions>['refetchQueries']
   }
 
 export type UpdateElementFormProps = Omit<
@@ -32,6 +34,7 @@ const UpdateElementFormInternal = ({
   tree,
   providePropCompletion,
   loadingStateKey,
+  refetchQueries,
   ...props
 }: React.PropsWithChildren<UpdateElementFormInternalProps>) => {
   const { current: element } = useRef(elementProp) // Cache the initial element value, because when it updates it will interfere with what the user is typing
@@ -45,6 +48,7 @@ const UpdateElementFormInternal = ({
     awaitRefetchQueries: true,
     refetchQueries: [
       refetchGetElementQuery({ input: { elementId: element.id } }),
+      ...(Array.isArray(refetchQueries) ? refetchQueries : []),
     ],
   })
 

--- a/libs/shared/abstract/core/src/enums/hooks/index.ts
+++ b/libs/shared/abstract/core/src/enums/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './hook-type'
+export * from './persistence-type'
 export * from './query-method'

--- a/libs/shared/abstract/core/src/enums/hooks/persistence-type.ts
+++ b/libs/shared/abstract/core/src/enums/hooks/persistence-type.ts
@@ -1,0 +1,5 @@
+export enum PersistenceType {
+  NotPersisted = 'NotPersisted',
+  LocalStorage = 'LocalStorage',
+  SessionStorage = 'SessionStorage',
+}

--- a/libs/shared/codegen/graphql/src/types.api.graphql.gen.ts
+++ b/libs/shared/codegen/graphql/src/types.api.graphql.gen.ts
@@ -910,6 +910,12 @@ export type PageByAppFilter = {
   appId: Scalars['String'];
 };
 
+export enum PersistenceType {
+  LocalStorage = 'LocalStorage',
+  NotPersisted = 'NotPersisted',
+  SessionStorage = 'SessionStorage'
+}
+
 export enum PrimitiveKind {
   Boolean = 'Boolean',
   Float = 'Float',
@@ -1110,11 +1116,13 @@ export type QueryPagesHookConfigInput = {
 export type RecoilStateHookConfig = {
   __typename?: 'RecoilStateHookConfig';
   defaultValue?: Maybe<Scalars['String']>;
+  persisted: PersistenceType;
   stateKey: Scalars['String'];
 };
 
 export type RecoilStateHookConfigInput = {
   defaultValue?: Maybe<Scalars['String']>;
+  persisted: PersistenceType;
   stateKey: Scalars['String'];
 };
 

--- a/schema.api.graphql
+++ b/schema.api.graphql
@@ -398,6 +398,13 @@ type GraphqlHookConfig {
 type RecoilStateHookConfig {
   stateKey: String!
   defaultValue: String
+  persisted: PersistenceType!
+}
+
+enum PersistenceType {
+  NotPersisted
+  LocalStorage
+  SessionStorage
 }
 
 type QueryPageHookConfig {
@@ -854,6 +861,7 @@ input GraphqlHookConfigInput {
 input RecoilStateHookConfigInput {
   stateKey: String!
   defaultValue: String
+  persisted: PersistenceType!
 }
 
 input QueryPageHookConfigInput {


### PR DESCRIPTION
- Fixes #1119 
- Fixed builder refetch bug - when assigning component to an element it didn't update 
- Added ability to persist recoil state hook data in local storage or session storage, use the persisted field when adding a RecoilState hook to an element
- Added ability to pass variables to GraphqlQuery and GraphqlMutation hooks. All element props are passed as variables, apollo seems to manage it well since it filters out unnecessary variables (i.e. ones not defined in the query/mutation block with $)

Note: the hook pipe is before propTransformationJsPipe and loopingRenderPipe, so it won't receive transformed or looped props. Only persisted props and props from parent mappings will be used as variables. That means we might need to lift some props up in order to use them as graphql variables and map them down to the required element with PropMappings
