### PR TITLE
1151 integrate redux (create codegen plugin)

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -66,26 +66,3 @@ generates:
       strictScalars: true
       defaultScalarType: unknown
       withRefetchFn: true
-
-  ./libs/front-end/:
-    documents:
-      - '**/*.{api,fragment}.graphql'
-    preset: near-operation-file
-    presetConfig:
-      extension: .graphql.gen.ts
-      baseTypesPath: ~@codelab/shared/codegen/graphql
-    plugins:
-      - typescript-operations
-      - dist/libs/tools/rtk-query:
-          importBaseApiFrom: '@codelab/frontend/model/infra/api'
-          exportHooks: true
-
-    config:
-      inlineFragmentTypes: combine
-      documentVariableSuffix: Gql
-      gqlImport: '@apollo/client#gql'
-      documentMode: '@apollo/client#gql'
-      skipTypename: true
-      strictScalars: true
-      defaultScalarType: unknown
-      withRefetchFn: true

--- a/codegen.yml
+++ b/codegen.yml
@@ -66,3 +66,26 @@ generates:
       strictScalars: true
       defaultScalarType: unknown
       withRefetchFn: true
+
+  ./libs/front-end/:
+    documents:
+      - '**/*.{api,fragment}.graphql'
+    preset: near-operation-file
+    presetConfig:
+      extension: .graphql.gen.ts
+      baseTypesPath: ~@codelab/shared/codegen/graphql
+    plugins:
+      - typescript-operations
+      - dist/libs/tools/rtk-query:
+          importBaseApiFrom: '@codelab/frontend/model/infra/api'
+          exportHooks: true
+
+    config:
+      inlineFragmentTypes: combine
+      documentVariableSuffix: Gql
+      gqlImport: '@apollo/client#gql'
+      documentMode: '@apollo/client#gql'
+      skipTypename: true
+      strictScalars: true
+      defaultScalarType: unknown
+      withRefetchFn: true

--- a/libs/tools/rtk-query/.babelrc
+++ b/libs/tools/rtk-query/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/tools/rtk-query/.eslintrc.json
+++ b/libs/tools/rtk-query/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/tools/rtk-query/README.md
+++ b/libs/tools/rtk-query/README.md
@@ -1,0 +1,7 @@
+# tools-rtk-query
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test tools-rtk-query` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/tools/rtk-query/jest.config.js
+++ b/libs/tools/rtk-query/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  displayName: 'tools-rtk-query',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'babel-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/libs/tools/rtk-query',
+}

--- a/libs/tools/rtk-query/package.json
+++ b/libs/tools/rtk-query/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@codelab/rtk-query",
+  "version": "0.0.1"
+}

--- a/libs/tools/rtk-query/src/config.ts
+++ b/libs/tools/rtk-query/src/config.ts
@@ -1,0 +1,69 @@
+import {
+  ClientSideBasePluginConfig,
+  RawClientSideBasePluginConfig,
+} from '@graphql-codegen/visitor-plugin-common'
+
+export interface RTKConfig {
+  /**
+   * @name importBaseApiFrom
+   * @description Define where to import the base api to inject endpoints into
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   ./src/app/api/generated.ts:
+   *     plugins:
+   *       - typescript
+   *       - typescript-operations
+   *       - typescript-rtk-query:
+   *           importBaseApiFrom: 'src/app/api/baseApi'
+   * ```
+   */
+  importBaseApiFrom: string
+  /**
+   * @name exportHooks
+   * @description Whether to export React Hooks from the generated api. Enable only when using the `"@reduxjs/toolkit/query/react"` import of `createApi`
+   * @default false
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   ./src/app/api/generated.ts:
+   *     plugins:
+   *       - typescript
+   *       - typescript-operations
+   *       - typescript-rtk-query:
+   *           importBaseApiFrom: 'src/app/api/baseApi'
+   *           exportHooks: true
+   * ```
+   */
+  exportHooks?: boolean
+  /**
+   * @name overrideExisting
+   * @description Sets the `overrideExisting` option, for example to allow for hot module reloading when running graphql-codegen in watch mode.
+   * Will directly be injected as code.
+   * @default undefined
+   *
+   * @exampleMarkdown
+   * ```yml
+   * generates:
+   *   ./src/app/api/generated.ts:
+   *     plugins:
+   *       - add:
+   *           content: 'module.hot?.accept();'
+   *       - typescript
+   *       - typescript-operations
+   *       - typescript-rtk-query:
+   *           importBaseApiFrom: 'src/app/api/baseApi'
+   *           overrideExisting: 'module.hot?.status() === "apply"'
+   * ```
+   */
+  overrideExisting?: string
+}
+
+export interface RTKQueryRawPluginConfig
+  extends RawClientSideBasePluginConfig,
+    RTKConfig {}
+export interface RTKQueryPluginConfig
+  extends ClientSideBasePluginConfig,
+    RTKConfig {}

--- a/libs/tools/rtk-query/src/index.ts
+++ b/libs/tools/rtk-query/src/index.ts
@@ -1,0 +1,76 @@
+import {
+  PluginFunction,
+  PluginValidateFn,
+  Types,
+} from '@graphql-codegen/plugin-helpers'
+import { LoadedFragment } from '@graphql-codegen/visitor-plugin-common'
+import {
+  concatAST,
+  DocumentNode,
+  FragmentDefinitionNode,
+  GraphQLSchema,
+  Kind,
+  visit,
+} from 'graphql'
+import { extname } from 'path'
+import { RTKQueryRawPluginConfig } from './config'
+import { RTKQueryVisitor } from './visitor'
+
+export const plugin: PluginFunction<
+  RTKQueryRawPluginConfig,
+  Types.ComplexPluginOutput
+> = (
+  schema: GraphQLSchema,
+  documents: Array<Types.DocumentFile>,
+  config: RTKQueryRawPluginConfig,
+) => {
+  const allAst = concatAST(documents.map((v) => v.document as DocumentNode))
+
+  const allFragments: Array<LoadedFragment> = [
+    ...(
+      allAst.definitions.filter(
+        (d) => d.kind === Kind.FRAGMENT_DEFINITION,
+      ) as Array<FragmentDefinitionNode>
+    ).map((fragmentDef) => ({
+      node: fragmentDef,
+      name: fragmentDef.name.value,
+      onType: fragmentDef.typeCondition.name.value,
+      isExternal: false,
+    })),
+    ...(config.externalFragments || []),
+  ]
+
+  const visitor = new RTKQueryVisitor(schema, allFragments, config, documents)
+  const visitorResult = visit(allAst, { leave: visitor })
+
+  return {
+    prepend: visitor.getImports(),
+    content: [
+      visitor.fragments,
+      ...visitorResult.definitions.filter((t: any) => typeof t === 'string'),
+      visitor.getInjectCall(),
+    ].join('\n'),
+  }
+}
+
+export const validate: PluginValidateFn<any> = async (
+  schema: GraphQLSchema,
+  documents: Array<Types.DocumentFile>,
+  config: RTKQueryRawPluginConfig,
+  outputFile: string,
+) => {
+  if (extname(outputFile) !== '.ts' && extname(outputFile) !== '.tsx') {
+    throw new Error(
+      `Plugin "typescript-rtk-query" requires extension to be ".ts" or ".tsx"!`,
+    )
+  }
+
+  if (!config.importBaseApiFrom) {
+    throw new Error(
+      `You must specify the "importBaseApiFrom" option to use the RTK Query plugin!` +
+        JSON.stringify(config),
+    )
+  }
+}
+
+export { RTKQueryVisitor }

--- a/libs/tools/rtk-query/src/index.ts
+++ b/libs/tools/rtk-query/src/index.ts
@@ -43,13 +43,18 @@ export const plugin: PluginFunction<
   const visitor = new RTKQueryVisitor(schema, allFragments, config, documents)
   const visitorResult = visit(allAst, { leave: visitor })
 
+  const requiredSegment = [
+    visitor.fragments,
+    ...visitorResult.definitions.filter((t: any) => typeof t === 'string'),
+  ].join('\n')
+
+  const injectedEndpoints = visitor.getInjectCall()
+
   return {
     prepend: visitor.getImports(),
-    content: [
-      visitor.fragments,
-      ...visitorResult.definitions.filter((t: any) => typeof t === 'string'),
-      visitor.getInjectCall(),
-    ].join('\n'),
+    content: injectedEndpoints
+      ? [requiredSegment, injectedEndpoints].join('\n')
+      : requiredSegment,
   }
 }
 

--- a/libs/tools/rtk-query/src/visitor.ts
+++ b/libs/tools/rtk-query/src/visitor.ts
@@ -1,0 +1,132 @@
+import { Types } from '@graphql-codegen/plugin-helpers'
+import {
+  ClientSideBaseVisitor,
+  getConfigValue,
+  LoadedFragment,
+} from '@graphql-codegen/visitor-plugin-common'
+import autoBind from 'auto-bind'
+import { pascalCase } from 'change-case-all'
+import { GraphQLSchema, OperationDefinitionNode } from 'graphql'
+import { RTKQueryPluginConfig, RTKQueryRawPluginConfig } from './config'
+
+export class RTKQueryVisitor extends ClientSideBaseVisitor<
+  RTKQueryRawPluginConfig,
+  RTKQueryPluginConfig
+> {
+  private _externalImportPrefix: string
+
+  private _endpoints: Array<string> = []
+
+  private _hooks: Array<string> = []
+
+  constructor(
+    schema: GraphQLSchema,
+    fragments: Array<LoadedFragment>,
+    protected rawConfig: RTKQueryRawPluginConfig,
+    documents: Array<Types.DocumentFile>,
+  ) {
+    super(schema, fragments, rawConfig, {
+      exportHooks: getConfigValue(rawConfig.exportHooks, false),
+      overrideExisting: getConfigValue(rawConfig.overrideExisting, ''),
+    })
+    this._externalImportPrefix = this.config.importOperationTypesFrom
+      ? `${this.config.importOperationTypesFrom}.`
+      : ''
+    this._documents = documents
+
+    autoBind(this)
+  }
+
+  public get imports(): Set<string> {
+    return this._imports
+  }
+
+  public get hasOperations() {
+    return this._collectedOperations.length > 0
+  }
+
+  public getImports(): Array<string> {
+    const baseImports = super.getImports()
+
+    if (!this.hasOperations) {
+      return baseImports
+    }
+
+    return [
+      ...baseImports,
+      `import { api } from '${this.config.importBaseApiFrom}';`,
+    ]
+  }
+
+  public getInjectCall() {
+    return (
+      `
+  const injectedRtkApi = api.injectEndpoints({
+    ${
+      !this.config.overrideExisting
+        ? ''
+        : `overrideExisting: ${this.config.overrideExisting},
+    `
+    }endpoints: (build) => ({${this._endpoints.join('')}
+    }),
+  });
+  export { injectedRtkApi as api };
+  ` +
+      (this.config.exportHooks
+        ? `export const { ${this._hooks.join(', ')} } = injectedRtkApi;`
+        : '') +
+      '\n\n'
+    )
+  }
+
+  protected buildOperation(
+    node: OperationDefinitionNode,
+    documentVariableName: string,
+    operationType: string,
+    operationResultType: string,
+    operationVariablesTypes: string,
+    hasRequiredVariables: boolean,
+  ): string {
+    operationResultType = this._externalImportPrefix + operationResultType
+    operationVariablesTypes =
+      this._externalImportPrefix + operationVariablesTypes
+
+    const operationName = node.name?.value
+
+    if (!operationName) {
+      return ''
+    }
+
+    const Generics = `${operationResultType}, ${operationVariablesTypes}${
+      hasRequiredVariables ? '' : ' | void'
+    }`
+
+    if (operationType === 'Query') {
+      this._endpoints.push(`
+      ${operationName}: build.query<${Generics}>({
+        query: (variables) => ({ document: ${documentVariableName}, variables })
+      }),`)
+
+      if (this.config.exportHooks) {
+        this._hooks.push(`use${pascalCase(operationName)}Query`)
+        this._hooks.push(`useLazy${pascalCase(operationName)}Query`)
+      }
+    } else if (operationType === 'Mutation') {
+      this._endpoints.push(`
+      ${operationName}: build.mutation<${Generics}>({
+        query: (variables) => ({ document: ${documentVariableName}, variables })
+      }),`)
+
+      if (this.config.exportHooks) {
+        this._hooks.push(`use${pascalCase(operationName)}Mutation`)
+      }
+    } else if (operationType === 'Subscription') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Plugin "typescript-rtk-query" does not support GraphQL Subscriptions at the moment! Skipping "${node.name?.value}"...`,
+      )
+    }
+
+    return ''
+  }
+}

--- a/libs/tools/rtk-query/src/visitor.ts
+++ b/libs/tools/rtk-query/src/visitor.ts
@@ -9,6 +9,8 @@ import { pascalCase } from 'change-case-all'
 import { GraphQLSchema, OperationDefinitionNode } from 'graphql'
 import { RTKQueryPluginConfig, RTKQueryRawPluginConfig } from './config'
 
+const DEFAULT_GQL_IMPORT_PACKAGE = `@apollo/client#gql`
+
 export class RTKQueryVisitor extends ClientSideBaseVisitor<
   RTKQueryRawPluginConfig,
   RTKQueryPluginConfig
@@ -28,6 +30,11 @@ export class RTKQueryVisitor extends ClientSideBaseVisitor<
     super(schema, fragments, rawConfig, {
       exportHooks: getConfigValue(rawConfig.exportHooks, false),
       overrideExisting: getConfigValue(rawConfig.overrideExisting, ''),
+      importBaseApiFrom: getConfigValue(rawConfig.importBaseApiFrom, ''),
+      gqlImport: getConfigValue(
+        rawConfig.gqlImport,
+        `${DEFAULT_GQL_IMPORT_PACKAGE}`,
+      ),
     })
     this._externalImportPrefix = this.config.importOperationTypesFrom
       ? `${this.config.importOperationTypesFrom}.`

--- a/libs/tools/rtk-query/src/visitor.ts
+++ b/libs/tools/rtk-query/src/visitor.ts
@@ -9,8 +9,6 @@ import { pascalCase } from 'change-case-all'
 import { GraphQLSchema, OperationDefinitionNode } from 'graphql'
 import { RTKQueryPluginConfig, RTKQueryRawPluginConfig } from './config'
 
-const DEFAULT_GQL_IMPORT_PACKAGE = `@apollo/client#gql`
-
 export class RTKQueryVisitor extends ClientSideBaseVisitor<
   RTKQueryRawPluginConfig,
   RTKQueryPluginConfig
@@ -29,12 +27,8 @@ export class RTKQueryVisitor extends ClientSideBaseVisitor<
   ) {
     super(schema, fragments, rawConfig, {
       exportHooks: getConfigValue(rawConfig.exportHooks, false),
-      overrideExisting: getConfigValue(rawConfig.overrideExisting, ''),
       importBaseApiFrom: getConfigValue(rawConfig.importBaseApiFrom, ''),
-      gqlImport: getConfigValue(
-        rawConfig.gqlImport,
-        `${DEFAULT_GQL_IMPORT_PACKAGE}`,
-      ),
+      overrideExisting: getConfigValue(rawConfig.overrideExisting, ''),
     })
     this._externalImportPrefix = this.config.importOperationTypesFrom
       ? `${this.config.importOperationTypesFrom}.`
@@ -66,6 +60,10 @@ export class RTKQueryVisitor extends ClientSideBaseVisitor<
   }
 
   public getInjectCall() {
+    if (this._endpoints.length === 0) {
+      return
+    }
+
     return (
       `
   const injectedRtkApi = api.injectEndpoints({

--- a/libs/tools/rtk-query/tsconfig.json
+++ b/libs/tools/rtk-query/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/tools/rtk-query/tsconfig.lib.json
+++ b/libs/tools/rtk-query/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2018",
+    "esModuleInterop": true,
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/tools/rtk-query/tsconfig.spec.json
+++ b/libs/tools/rtk-query/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/nx.json
+++ b/nx.json
@@ -188,6 +188,9 @@
     "tools-plugins-codelab": {
       "tags": ["scope:publishable"]
     },
+    "tools-rtk-query": {
+      "tags": []
+    },
     "tools-scripts": {
       "tags": []
     },

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "react-helmet": "6.1.0",
     "react-hotkeys-hook": "^3.4.3",
     "react-json-view": "1.21.3",
-    "react-query": "3.25.1",
+    "react-query": "^3.31.0",
     "react-redux": "^7.2.5",
     "react-resizable": "3.0.4",
     "recoil": "0.4.1",

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -3,5 +3,5 @@
 set -x
 
 husky install
- nx run-many --target=build --projects=cli,cmd,tools-plugins-codelab
- yarn cli dgraph update-schema --env dev
+nx run-many --target=build --projects=cli,tools-plugins-codelab,tools-rtk-query
+yarn cli dgraph update-schema --env dev

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -177,7 +177,8 @@
         "libs/tools/plugins/codelab/src/index.ts"
       ],
       "@codelab/tools/scripts": ["libs/tools/scripts/src/index.ts"],
-      "@codelab/ui/d3": ["libs/ui/d3/src/index.ts"]
+      "@codelab/ui/d3": ["libs/ui/d3/src/index.ts"],
+      "@codelab/rtk-query": ["libs/tools/rtk-query/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp", "dist", ".gqlcodegen"]

--- a/workspace.json
+++ b/workspace.json
@@ -1483,6 +1483,39 @@
         }
       }
     },
+    "tools-rtk-query": {
+      "root": "libs/tools/rtk-query",
+      "sourceRoot": "libs/tools/rtk-query/src",
+      "projectType": "library",
+      "architect": {
+        "build": {
+          "builder": "@nrwl/node:package",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "outputPath": "dist/libs/tools/rtk-query",
+            "tsConfig": "libs/tools/rtk-query/tsconfig.lib.json",
+            "packageJson": "libs/tools/rtk-query/package.json",
+            "main": "libs/tools/rtk-query/src/index.ts",
+            "assets": ["libs/tools/rtk-query/*.md"]
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "outputs": ["{options.outputFile}"],
+          "options": {
+            "lintFilePatterns": ["libs/tools/rtk-query/**/*.ts"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/tools/rtk-query"],
+          "options": {
+            "jestConfig": "libs/tools/rtk-query/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
     "tools-scripts": {
       "root": "libs/tools/scripts",
       "sourceRoot": "libs/tools/scripts/src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23825,10 +23825,10 @@ react-popper@^2.2.4:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
-react-query@3.25.1:
-  version "3.25.1"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.25.1.tgz#221ff17406518a7689378dcbbdc986b0ba2c3919"
-  integrity sha512-tGZkap921d9dJD2F8+NpEu3djLRP+tpZKHKhQvqUMYMfWT5R18iRtGAG5ZeUMlRKuhzNaZx3cHiYj3DsyZ1SWw==
+react-query@^3.31.0:
+  version "3.31.0"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.31.0.tgz#297add9301d15ef2e004297e72a8e46f7aa5616a"
+  integrity sha512-6NiXgjdXBKGA9ge04NI21uqTCIpH6qzR8AGGom/nR/emaGc//D9KM6C6+AEy8zLYl4RYjvd/XhA3lWME5kGMiw==
   dependencies:
     "@babel/runtime" "^7.5.5"
     broadcast-channel "^3.4.1"


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->
This plugins extends the official one https://www.graphql-code-generator.com/docs/plugins/typescript-rtk-query with the following :
- Ability to use `gqlImport` to use typed queries instead of pure strings
- Escape empty endpoints files such fragments (doesn't inject api code unless there is a valid endpoints)  
## Current Behavior

<!-- This is the behavior we have today -->

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
