### PR TITLE
feat: add notifications and code refactors

### DIFF
--- a/libs/frontend/modules/admin/src/use-cases/reset-data/ResetDataButton.tsx
+++ b/libs/frontend/modules/admin/src/use-cases/reset-data/ResetDataButton.tsx
@@ -1,9 +1,22 @@
+import { useNotify } from '@codelab/frontend/shared/utils'
 import { Button } from 'antd'
 import { useResetDataMutation } from '../../store'
 
 export const ResetDataButton = () => {
   const [resetData] = useResetDataMutation()
-  const onClick = () => resetData()
+
+  const { onSuccess, onError } = useNotify(
+    {
+      title: 'Data has been reset successfully',
+      type: 'success',
+    },
+    {
+      title: 'Failed to reset Data',
+      type: 'error',
+    },
+  )
+
+  const onClick = () => resetData().unwrap().then(onSuccess).catch(onError)
 
   return <Button onClick={onClick}>Reset Data</Button>
 }

--- a/libs/frontend/modules/admin/src/use-cases/reset-data/ResetDataButton.tsx
+++ b/libs/frontend/modules/admin/src/use-cases/reset-data/ResetDataButton.tsx
@@ -6,14 +6,8 @@ export const ResetDataButton = () => {
   const [resetData] = useResetDataMutation()
 
   const { onSuccess, onError } = useNotify(
-    {
-      title: 'Data has been reset successfully',
-      type: 'success',
-    },
-    {
-      title: 'Failed to reset Data',
-      type: 'error',
-    },
+    { title: 'Data has been reset successfully' },
+    { title: 'Failed to reset Data' },
   )
 
   const onClick = () => resetData().unwrap().then(onSuccess).catch(onError)

--- a/libs/frontend/modules/admin/src/use-cases/seed-base-types/SeedBaseTypesButton.tsx
+++ b/libs/frontend/modules/admin/src/use-cases/seed-base-types/SeedBaseTypesButton.tsx
@@ -6,14 +6,8 @@ export const SeedBaseTypesButton = () => {
   const [seedBaseTypes] = useSeedBaseTypesMutation()
 
   const { onSuccess, onError } = useNotify(
-    {
-      title: 'BaseTypes has been seeded successfully',
-      type: 'success',
-    },
-    {
-      title: 'Failed to seed BaseTypes',
-      type: 'error',
-    },
+    { title: 'BaseTypes has been seeded successfully' },
+    { title: 'Failed to seed BaseTypes' },
   )
 
   const onClick = () => seedBaseTypes().unwrap().then(onSuccess).catch(onError)

--- a/libs/frontend/modules/admin/src/use-cases/seed-base-types/SeedBaseTypesButton.tsx
+++ b/libs/frontend/modules/admin/src/use-cases/seed-base-types/SeedBaseTypesButton.tsx
@@ -1,9 +1,22 @@
+import { useNotify } from '@codelab/frontend/shared/utils'
 import { Button } from 'antd'
 import { useSeedBaseTypesMutation } from '../../store'
 
 export const SeedBaseTypesButton = () => {
   const [seedBaseTypes] = useSeedBaseTypesMutation()
-  const onClick = () => seedBaseTypes()
+
+  const { onSuccess, onError } = useNotify(
+    {
+      title: 'BaseTypes has been seeded successfully',
+      type: 'success',
+    },
+    {
+      title: 'Failed to seed BaseTypes',
+      type: 'error',
+    },
+  )
+
+  const onClick = () => seedBaseTypes().unwrap().then(onSuccess).catch(onError)
 
   return <Button onClick={onClick}>Seed Base Types</Button>
 }

--- a/libs/frontend/modules/app/src/hooks/useAppDispatch.ts
+++ b/libs/frontend/modules/app/src/hooks/useAppDispatch.ts
@@ -1,44 +1,18 @@
+import { crudModalDispatchFactory } from '@codelab/frontend/view/components'
 import { useDispatch } from 'react-redux'
-import {
-  appSlice,
-  OpenDeleteAppModalAction,
-  OpenUpdateAppModalAction,
-  SetCurrentAppAction,
-} from '../store'
+import { appSlice, SetCurrentAppAction } from '../store'
 
 export const useAppDispatch = () => {
   const dispatch = useDispatch()
   const { actions } = appSlice
-
-  const openCreateModal = () => {
-    dispatch(actions.openCreateModal())
-  }
-
-  const openDeleteModal = (payload: OpenDeleteAppModalAction) =>
-    dispatch(actions.openDeleteModal(payload))
-
-  const openUpdateModal = (payload: OpenUpdateAppModalAction) => {
-    dispatch(actions.openUpdateModal(payload))
-  }
-
-  const openImportModal = () => {
-    dispatch(actions.openImportModal())
-  }
-
-  const reset = () => {
-    dispatch(actions.reset())
-  }
+  const curdDispatch = crudModalDispatchFactory(appSlice.actions)()
 
   const setCurrentApp = (payload: SetCurrentAppAction) => {
     dispatch(actions.setCurrentApp(payload))
   }
 
   return {
-    openCreateModal,
-    openDeleteModal,
-    openUpdateModal,
-    openImportModal,
     setCurrentApp,
-    reset,
+    ...curdDispatch,
   }
 }

--- a/libs/frontend/modules/app/src/hooks/useAppDispatch.ts
+++ b/libs/frontend/modules/app/src/hooks/useAppDispatch.ts
@@ -7,11 +7,16 @@ export const useAppDispatch = () => {
   const { actions } = appSlice
   const curdDispatch = crudModalDispatchFactory(appSlice.actions)()
 
+  const openImportModal = () => {
+    dispatch(actions.openImportModal())
+  }
+
   const setCurrentApp = (payload: SetCurrentAppAction) => {
     dispatch(actions.setCurrentApp(payload))
   }
 
   return {
+    openImportModal,
     setCurrentApp,
     ...curdDispatch,
   }

--- a/libs/frontend/modules/app/src/use-cases/create-app/CreateAppButton.tsx
+++ b/libs/frontend/modules/app/src/use-cases/create-app/CreateAppButton.tsx
@@ -7,9 +7,10 @@ import { CreateAppButtonProps } from './types'
 export const CreateAppButton = ({ createNow }: CreateAppButtonProps) => {
   const { openCreateModal } = useAppDispatch()
   const icon = !createNow && <PlusOutlined />
+  const onClick = () => openCreateModal()
 
   return (
-    <Button onClick={openCreateModal} icon={icon} type="primary">
+    <Button onClick={onClick} icon={icon} type="primary">
       {createNow ? 'Create Now' : 'Create App'}
     </Button>
   )

--- a/libs/frontend/modules/app/src/use-cases/create-app/useCreateAppForm.ts
+++ b/libs/frontend/modules/app/src/use-cases/create-app/useCreateAppForm.ts
@@ -6,7 +6,7 @@ import { useCreateAppMutation } from '../../store'
 import { CreateAppFormProps } from './types'
 
 export const useCreateAppForm = () => {
-  const { reset } = useAppDispatch()
+  const { resetModal } = useAppDispatch()
 
   const [mutate, state] = useCreateAppMutation({
     selectFromResult: (r) => ({
@@ -18,7 +18,7 @@ export const useCreateAppForm = () => {
 
   const onSubmit = useCallback(
     (input: CreateAppInput) => {
-      return mutate({ variables: { input } })
+      return mutate({ variables: { input } }).unwrap()
     },
     [mutate],
   )
@@ -27,7 +27,7 @@ export const useCreateAppForm = () => {
     title: 'Error while creating app',
   })
 
-  const onSubmitSuccess = () => reset()
+  const onSubmitSuccess = () => resetModal()
 
   const formProps: CreateAppFormProps = {
     onSubmit,
@@ -39,6 +39,6 @@ export const useCreateAppForm = () => {
   return {
     formProps,
     state,
-    reset,
+    reset: resetModal,
   }
 }

--- a/libs/frontend/modules/app/src/use-cases/delete-app/useDeleteAppForm.ts
+++ b/libs/frontend/modules/app/src/use-cases/delete-app/useDeleteAppForm.ts
@@ -6,7 +6,7 @@ import { DeleteAppFormProps, DeleteAppMutationInput } from './types'
 
 export const useDeleteAppForm = () => {
   const { deleteIds, entity } = useAppState()
-  const { reset } = useAppDispatch()
+  const { resetModal } = useAppDispatch()
 
   const [mutate, state] = useDeleteAppMutation({
     selectFromResult: (r) => ({
@@ -17,7 +17,8 @@ export const useDeleteAppForm = () => {
   })
 
   const onSubmit = useCallback(
-    (input: DeleteAppMutationInput) => mutate({ variables: { input } }),
+    (input: DeleteAppMutationInput) =>
+      mutate({ variables: { input } }).unwrap(),
     [mutate],
   )
 
@@ -25,7 +26,7 @@ export const useDeleteAppForm = () => {
     title: 'Error while deleting app',
   })
 
-  const onSubmitSuccess = () => reset()
+  const onSubmitSuccess = () => resetModal()
 
   const formProps: DeleteAppFormProps = {
     onSubmit,
@@ -38,6 +39,6 @@ export const useDeleteAppForm = () => {
   return {
     formProps,
     state,
-    reset,
+    reset: resetModal,
   }
 }

--- a/libs/frontend/modules/app/src/use-cases/import-app/useImportAppForm.ts
+++ b/libs/frontend/modules/app/src/use-cases/import-app/useImportAppForm.ts
@@ -6,7 +6,7 @@ import { ImportAppFormProps } from './ImportAppForm'
 import { ImportAppSchema } from './importAppSchema'
 
 export const useImportAppForm = () => {
-  const { reset } = useAppDispatch()
+  const { resetModal } = useAppDispatch()
 
   const [mutate, state] = useImportAppMutation({
     selectFromResult: (r) => ({
@@ -25,12 +25,12 @@ export const useImportAppForm = () => {
         throw new Error("Can't parse file") // shouldn't happen, we test in the form
       }
 
-      return mutate({ variables: { input: { payload: text } } })
+      return mutate({ variables: { input: { payload: text } } }).unwrap()
     },
     [mutate],
   )
 
-  const onSubmitSuccess = () => reset()
+  const onSubmitSuccess = () => resetModal()
 
   const onSubmitError = createNotificationHandler({
     title: 'Error while importing app',
@@ -45,6 +45,6 @@ export const useImportAppForm = () => {
   return {
     formProps,
     state,
-    reset,
+    reset: resetModal,
   }
 }

--- a/libs/frontend/modules/app/src/use-cases/update-app/useUpdateAppForm.ts
+++ b/libs/frontend/modules/app/src/use-cases/update-app/useUpdateAppForm.ts
@@ -20,7 +20,7 @@ export const useUpdateAppForm = () => {
     (data: UpdateAppMutationInput) => {
       return mutate({
         variables: { input: { data, id: updateId } },
-      })
+      }).unwrap()
     },
     [mutate, updateId],
   )

--- a/libs/frontend/modules/app/src/use-cases/update-app/useUpdateAppForm.ts
+++ b/libs/frontend/modules/app/src/use-cases/update-app/useUpdateAppForm.ts
@@ -6,7 +6,7 @@ import { UpdateAppFormProps, UpdateAppMutationInput } from './types'
 
 export const useUpdateAppForm = () => {
   const { updateId, entity } = useAppState()
-  const { reset } = useAppDispatch()
+  const { resetModal } = useAppDispatch()
 
   const [mutate, state] = useUpdateAppMutation({
     selectFromResult: (r) => ({
@@ -29,7 +29,7 @@ export const useUpdateAppForm = () => {
     title: 'Error while updateing app',
   })
 
-  const onSubmitSuccess = () => reset()
+  const onSubmitSuccess = () => resetModal()
 
   const formProps: UpdateAppFormProps = {
     onSubmit,
@@ -43,6 +43,6 @@ export const useUpdateAppForm = () => {
   return {
     formProps,
     state,
-    reset,
+    reset: resetModal,
   }
 }

--- a/libs/frontend/modules/atom/src/hooks/useAtomDispatch.ts
+++ b/libs/frontend/modules/atom/src/hooks/useAtomDispatch.ts
@@ -1,39 +1,18 @@
+import { crudModalDispatchFactory } from '@codelab/frontend/view/components'
 import { useDispatch } from 'react-redux'
-import {
-  atomSlice,
-  OpenDeleteAtomModalAction,
-  OpenUpdateAtomModalAction,
-  SetSelectedAtomIdsModalAction,
-} from '../store'
+import { atomSlice, SetSelectedAtomIdsModalAction } from '../store'
 
 export const useAtomDispatch = () => {
   const dispatch = useDispatch()
   const { actions } = atomSlice
-
-  const openCreateModal = () => {
-    dispatch(actions.openCreateModal())
-  }
-
-  const openDeleteModal = (payload: OpenDeleteAtomModalAction) =>
-    dispatch(actions.openDeleteModal(payload))
-
-  const openUpdateModal = (payload: OpenUpdateAtomModalAction) => {
-    dispatch(actions.openUpdateModal(payload))
-  }
+  const curdDispatch = crudModalDispatchFactory(atomSlice.actions)()
 
   const setSelectedIds = (payload: SetSelectedAtomIdsModalAction) => {
     dispatch(actions.setSelectedIds(payload))
   }
 
-  const reset = () => {
-    dispatch(actions.reset())
-  }
-
   return {
-    openCreateModal,
-    openDeleteModal,
-    openUpdateModal,
     setSelectedIds,
-    reset,
+    ...curdDispatch,
   }
 }

--- a/libs/frontend/modules/atom/src/store/atomEndpoints.ts
+++ b/libs/frontend/modules/atom/src/store/atomEndpoints.ts
@@ -9,6 +9,9 @@ import { api as generatedApi } from '../graphql/Atom.endpoints.graphql.gen'
 
 export const api = generatedApi.enhanceEndpoints({
   endpoints: {
+    ExportAtoms: {
+      providesTags: (result) => providesAll(result?.getAtoms, ATOMS_CACHE_TAG),
+    },
     GetAtoms: {
       providesTags: (result) => providesAll(result?.getAtoms, ATOMS_CACHE_TAG),
     },
@@ -25,6 +28,9 @@ export const api = generatedApi.enhanceEndpoints({
     UpdateAtom: {
       invalidatesTags: (result) =>
         invalidatesById(result?.updateAtom?.id, ATOMS_CACHE_TAG),
+    },
+    ImportAtoms: {
+      invalidatesTags: () => invalidatesAll(ATOMS_CACHE_TAG),
     },
   },
 })

--- a/libs/frontend/modules/atom/src/use-cases/create-atom/useCreateAtomForm.ts
+++ b/libs/frontend/modules/atom/src/use-cases/create-atom/useCreateAtomForm.ts
@@ -6,7 +6,7 @@ import { useCreateAtomMutation } from '../../store'
 import { CreateAtomFormProps } from './types'
 
 export const useCreateAtomForm = () => {
-  const { reset } = useAtomDispatch()
+  const { resetModal } = useAtomDispatch()
 
   const [mutate, state] = useCreateAtomMutation({
     selectFromResult: (r) => ({
@@ -18,7 +18,7 @@ export const useCreateAtomForm = () => {
 
   const onSubmit = useCallback(
     (input: CreateAtomInput) => {
-      return mutate({ variables: { input } })
+      return mutate({ variables: { input } }).unwrap()
     },
     [mutate],
   )
@@ -27,7 +27,7 @@ export const useCreateAtomForm = () => {
     title: 'Error while creating atom',
   })
 
-  const onSubmitSuccess = () => reset()
+  const onSubmitSuccess = () => resetModal()
 
   const formProps: CreateAtomFormProps = {
     onSubmit,
@@ -39,6 +39,6 @@ export const useCreateAtomForm = () => {
   return {
     formProps,
     state,
-    reset,
+    reset: resetModal,
   }
 }

--- a/libs/frontend/modules/atom/src/use-cases/delete-atom/useDeleteAtomForm.ts
+++ b/libs/frontend/modules/atom/src/use-cases/delete-atom/useDeleteAtomForm.ts
@@ -6,7 +6,7 @@ import { DeleteAtomMutationInput, DeleteAtomsFormProps } from './types'
 
 export const useDeleteAtomForm = () => {
   const { deleteIds, entity } = useAtomState()
-  const { reset } = useAtomDispatch()
+  const { resetModal } = useAtomDispatch()
 
   const [mutate, state] = useDeleteAtomMutation({
     selectFromResult: (r) => ({
@@ -17,7 +17,8 @@ export const useDeleteAtomForm = () => {
   })
 
   const onSubmit = useCallback(
-    (input: DeleteAtomMutationInput) => mutate({ variables: { input } }),
+    (input: DeleteAtomMutationInput) =>
+      mutate({ variables: { input } }).unwrap(),
     [mutate],
   )
 
@@ -25,7 +26,7 @@ export const useDeleteAtomForm = () => {
     title: 'Error while deleting atom',
   })
 
-  const onSubmitSuccess = () => reset()
+  const onSubmitSuccess = () => resetModal()
 
   const formProps: DeleteAtomsFormProps = {
     onSubmit,
@@ -38,6 +39,6 @@ export const useDeleteAtomForm = () => {
   return {
     formProps,
     state,
-    reset,
+    reset: resetModal,
   }
 }

--- a/libs/frontend/modules/atom/src/use-cases/export-atoms/ExportAtomsButton.tsx
+++ b/libs/frontend/modules/atom/src/use-cases/export-atoms/ExportAtomsButton.tsx
@@ -1,3 +1,4 @@
+import { notify } from '@codelab/frontend/shared/utils'
 import { Button } from 'antd'
 import fileDownload from 'js-file-download'
 import React from 'react'
@@ -5,7 +6,7 @@ import { useLazyExportAtomsQuery } from '../../store'
 import { ExportAtomsButtonProps } from './types'
 
 export const ExportAtomsButton = ({ atomIds }: ExportAtomsButtonProps) => {
-  const [getExportAtoms, { isLoading, data }] = useLazyExportAtomsQuery()
+  const [getExportAtoms, { isLoading, data, error }] = useLazyExportAtomsQuery()
 
   const onClick = async () => {
     await getExportAtoms({
@@ -20,8 +21,11 @@ export const ExportAtomsButton = ({ atomIds }: ExportAtomsButtonProps) => {
 
     if (data) {
       const content = JSON.stringify(data.getAtoms)
-      console.log(content)
       fileDownload(content, 'atoms.json')
+    }
+
+    if (error) {
+      notify({ title: 'Error while exporting atoms', type: 'error' })
     }
   }
 

--- a/libs/frontend/modules/atom/src/use-cases/import-atoms/ImportAtomsUpload.tsx
+++ b/libs/frontend/modules/atom/src/use-cases/import-atoms/ImportAtomsUpload.tsx
@@ -1,8 +1,14 @@
+import { useNotify } from '@codelab/frontend/shared/utils'
 import { ImportUpload } from '@codelab/frontend/view/components'
 import { useImportAtomsMutation } from '../../store'
 
 export const ImportAtomsUpload = () => {
   const [importAtoms] = useImportAtomsMutation()
+
+  const { onSuccess, onError } = useNotify(
+    { title: 'Atoms successfully imported' },
+    { title: 'Error while importing atoms' },
+  )
 
   const fetchFn = (data: any) =>
     importAtoms({
@@ -12,6 +18,9 @@ export const ImportAtomsUpload = () => {
         },
       },
     })
+      .unwrap()
+      .then(onSuccess)
+      .catch(onError)
 
   return <ImportUpload fetchFn={fetchFn} />
 }

--- a/libs/frontend/modules/atom/src/use-cases/update-atom/useUpdateAtomForm.ts
+++ b/libs/frontend/modules/atom/src/use-cases/update-atom/useUpdateAtomForm.ts
@@ -6,7 +6,7 @@ import { UpdateAtomFormProps, UpdateAtomMutationInput } from './types'
 
 export const useUpdateAtomForm = () => {
   const { updateId, entity } = useAtomState()
-  const { reset } = useAtomDispatch()
+  const { resetModal } = useAtomDispatch()
 
   const [mutate, state] = useUpdateAtomMutation({
     selectFromResult: (r) => ({
@@ -17,11 +17,10 @@ export const useUpdateAtomForm = () => {
   })
 
   const onSubmit = useCallback(
-    (data: UpdateAtomMutationInput) => {
-      return mutate({
+    (data: UpdateAtomMutationInput) =>
+      mutate({
         variables: { input: { data, id: updateId } },
-      })
-    },
+      }).unwrap(),
     [mutate, updateId],
   )
 
@@ -29,7 +28,7 @@ export const useUpdateAtomForm = () => {
     title: 'Error while updateing atom',
   })
 
-  const onSubmitSuccess = () => reset()
+  const onSubmitSuccess = () => resetModal()
 
   const formProps: UpdateAtomFormProps = {
     onSubmit,
@@ -44,6 +43,6 @@ export const useUpdateAtomForm = () => {
   return {
     formProps,
     state,
-    reset,
+    reset: resetModal,
   }
 }

--- a/libs/frontend/modules/builder/src/hooks/usePropsInspector.ts
+++ b/libs/frontend/modules/builder/src/hooks/usePropsInspector.ts
@@ -47,7 +47,7 @@ export const usePropsInspector = (elementId: string) => {
             data: JSON.stringify(JSON.parse(persistedProps)),
           },
         },
-      })
+      }).unwrap()
     } catch (e) {
       notify({ title: 'Invalid json', type: 'warning' })
     }

--- a/libs/frontend/modules/element/src/use-cases/component/create-component/useCreateComponentForm.ts
+++ b/libs/frontend/modules/element/src/use-cases/component/create-component/useCreateComponentForm.ts
@@ -26,7 +26,7 @@ export const useCreateComponentForm = () => {
     (submitData: CreateComponentSchemaType) => {
       const variables = mapVariables(submitData)
 
-      return mutate({ variables })
+      return mutate({ variables }).unwrap()
     },
     [mutate],
   )

--- a/libs/frontend/modules/element/src/use-cases/element/create-element/useCreateElementForm.ts
+++ b/libs/frontend/modules/element/src/use-cases/element/create-element/useCreateElementForm.ts
@@ -51,7 +51,7 @@ export const useCreateElementForm = (
     (submitData: CreateElementSchema) => {
       const variables = mapVariables(submitData)
 
-      return mutate({ variables })
+      return mutate({ variables }).unwrap()
     },
     [mutate],
   )

--- a/libs/frontend/modules/element/src/use-cases/element/delete-element/useDeleteElementForm.ts
+++ b/libs/frontend/modules/element/src/use-cases/element/delete-element/useDeleteElementForm.ts
@@ -16,7 +16,9 @@ export const useDeleteElementForm = () => {
   })
 
   const handleSubmit = useCallback(() => {
-    return mutate({ variables: { input: { elementId: deleteIds[0] } } })
+    return mutate({
+      variables: { input: { elementId: deleteIds[0] } },
+    }).unwrap()
   }, [mutate, deleteIds])
 
   return {

--- a/libs/frontend/modules/element/src/use-cases/element/move-element/MoveElementForm.tsx
+++ b/libs/frontend/modules/element/src/use-cases/element/move-element/MoveElementForm.tsx
@@ -46,7 +46,7 @@ export const MoveElementForm = ({
       variables: {
         input: { elementId, moveData: { ...submitData } },
       },
-    })
+    }).unwrap()
 
     if (trackPromise) {
       trackPromise(promise)

--- a/libs/frontend/modules/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
+++ b/libs/frontend/modules/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
@@ -81,7 +81,7 @@ const UpdateElementPropsFormInternal = ({
                 propsId: existingProps.id,
               },
             },
-          })
+          }).unwrap()
 
           return trackPromise?.(promise) ?? promise
         }}

--- a/libs/frontend/modules/element/src/use-cases/hooks/add-hook-to-element/useAddHookToElementForm.ts
+++ b/libs/frontend/modules/element/src/use-cases/hooks/add-hook-to-element/useAddHookToElementForm.ts
@@ -53,7 +53,7 @@ export const useAddHookToElementForm = (elementId: string) => {
       return
     }
 
-    return mutate({ variables: { input } })
+    return mutate({ variables: { input } }).unwrap()
   }
 
   const reset = () => {

--- a/libs/frontend/modules/element/src/use-cases/hooks/remove-hook-from-element/useRemoveHookFromElementForm.ts
+++ b/libs/frontend/modules/element/src/use-cases/hooks/remove-hook-from-element/useRemoveHookFromElementForm.ts
@@ -19,7 +19,7 @@ export const useRemoveHookFromElementForm = (elementId: string) => {
   const handleSubmit = useCallback(() => {
     return mutate({
       variables: { input: { elementId, hookId: deleteIds[0] } },
-    })
+    }).unwrap()
   }, [mutate, elementId, deleteIds])
 
   return {

--- a/libs/frontend/modules/element/src/use-cases/prop-mapping/create-prop-map-binding/useCreatePropMapBindingForm.ts
+++ b/libs/frontend/modules/element/src/use-cases/prop-mapping/create-prop-map-binding/useCreatePropMapBindingForm.ts
@@ -31,7 +31,7 @@ export const useCreatePropMapBindingForm = () => {
             elementId,
           },
         },
-      })
+      }).unwrap()
     },
     [mutate],
   )

--- a/libs/frontend/modules/element/src/use-cases/prop-mapping/delete-prop-map-binding/useDeletePropMapBindingForm.ts
+++ b/libs/frontend/modules/element/src/use-cases/prop-mapping/delete-prop-map-binding/useDeletePropMapBindingForm.ts
@@ -23,7 +23,7 @@ export const useDeletePropMapBindingForm = () => {
       variables: {
         input: { propMapBindingIds: deleteIds },
       },
-    })
+    }).unwrap()
   }, [mutate, deleteIds])
 
   return {

--- a/libs/frontend/modules/element/src/use-cases/prop-mapping/update-prop-map-binding/useUpdatePropMapBindingForm.ts
+++ b/libs/frontend/modules/element/src/use-cases/prop-mapping/update-prop-map-binding/useUpdatePropMapBindingForm.ts
@@ -33,7 +33,7 @@ export const useUpdatePropMapBindingForm = () => {
             propMapBindingId: updateId,
           },
         },
-      })
+      }).unwrap()
     },
     [mutate, updateId],
   )

--- a/libs/frontend/modules/lambda/src/hooks/useLambdaDispatch.ts
+++ b/libs/frontend/modules/lambda/src/hooks/useLambdaDispatch.ts
@@ -1,33 +1,5 @@
-import { useDispatch } from 'react-redux'
-import {
-  lambdaSlice,
-  OpenDeleteLambdaModalAction,
-  OpenUpdateLambdaModalAction,
-} from '../store'
+import { crudModalDispatchFactory } from '@codelab/frontend/view/components'
+import { lambdaSlice } from '../store'
 
-export const useLambdaDispatch = () => {
-  const dispatch = useDispatch()
-  const { actions } = lambdaSlice
-
-  const openCreateModal = () => {
-    dispatch(actions.openCreateModal())
-  }
-
-  const openDeleteModal = (payload: OpenDeleteLambdaModalAction) =>
-    dispatch(actions.openDeleteModal(payload))
-
-  const openUpdateModal = (payload: OpenUpdateLambdaModalAction) => {
-    dispatch(actions.openUpdateModal(payload))
-  }
-
-  const reset = () => {
-    dispatch(actions.reset())
-  }
-
-  return {
-    openCreateModal,
-    openDeleteModal,
-    openUpdateModal,
-    reset,
-  }
-}
+export const useLambdaDispatch = () =>
+  crudModalDispatchFactory(lambdaSlice.actions)()

--- a/libs/frontend/modules/lambda/src/use-cases/create-lambda/useCreateLambdaForm.ts
+++ b/libs/frontend/modules/lambda/src/use-cases/create-lambda/useCreateLambdaForm.ts
@@ -7,7 +7,7 @@ import { defaultLambdaBody } from './defaultLambdBody'
 import { CreateLambdaFormProps } from './types'
 
 export const useCreateLambdaForm = () => {
-  const { reset } = useLambdaDispatch()
+  const { resetModal } = useLambdaDispatch()
 
   const [mutate, state] = useCreateLambdaMutation({
     selectFromResult: (r) => ({
@@ -28,7 +28,7 @@ export const useCreateLambdaForm = () => {
     title: 'Error while creating lambda',
   })
 
-  const onSubmitSuccess = () => reset()
+  const onSubmitSuccess = () => resetModal()
 
   const formProps: CreateLambdaFormProps = {
     onSubmit,
@@ -42,6 +42,6 @@ export const useCreateLambdaForm = () => {
   return {
     formProps,
     state,
-    reset,
+    reset: resetModal,
   }
 }

--- a/libs/frontend/modules/lambda/src/use-cases/create-lambda/useCreateLambdaForm.ts
+++ b/libs/frontend/modules/lambda/src/use-cases/create-lambda/useCreateLambdaForm.ts
@@ -18,9 +18,7 @@ export const useCreateLambdaForm = () => {
   })
 
   const onSubmit = useCallback(
-    (input: CreateLambdaInput) => {
-      return mutate({ variables: { input } })
-    },
+    (input: CreateLambdaInput) => mutate({ variables: { input } }).unwrap(),
     [mutate],
   )
 

--- a/libs/frontend/modules/lambda/src/use-cases/delete-lambda/useDeleteLambdaForm.ts
+++ b/libs/frontend/modules/lambda/src/use-cases/delete-lambda/useDeleteLambdaForm.ts
@@ -17,7 +17,8 @@ export const useDeleteLambdaForm = () => {
   })
 
   const onSubmit = useCallback(
-    (input: DeleteLambdaMutationInput) => mutate({ variables: { input } }),
+    (input: DeleteLambdaMutationInput) =>
+      mutate({ variables: { input } }).unwrap(),
     [mutate],
   )
 

--- a/libs/frontend/modules/lambda/src/use-cases/delete-lambda/useDeleteLambdaForm.ts
+++ b/libs/frontend/modules/lambda/src/use-cases/delete-lambda/useDeleteLambdaForm.ts
@@ -6,7 +6,7 @@ import { DeleteLambdaFormProps, DeleteLambdaMutationInput } from './types'
 
 export const useDeleteLambdaForm = () => {
   const { deleteIds, entity } = useLambdaState()
-  const { reset } = useLambdaDispatch()
+  const { resetModal } = useLambdaDispatch()
 
   const [mutate, state] = useDeleteLambdaMutation({
     selectFromResult: (r) => ({
@@ -25,7 +25,7 @@ export const useDeleteLambdaForm = () => {
     title: 'Error while deleting lambda',
   })
 
-  const onSubmitSuccess = () => reset()
+  const onSubmitSuccess = () => resetModal()
 
   const formProps: DeleteLambdaFormProps = {
     onSubmit,
@@ -38,6 +38,6 @@ export const useDeleteLambdaForm = () => {
   return {
     formProps,
     state,
-    reset,
+    resetModal,
   }
 }

--- a/libs/frontend/modules/lambda/src/use-cases/delete-lambda/useDeleteLambdaForm.ts
+++ b/libs/frontend/modules/lambda/src/use-cases/delete-lambda/useDeleteLambdaForm.ts
@@ -39,6 +39,6 @@ export const useDeleteLambdaForm = () => {
   return {
     formProps,
     state,
-    resetModal,
+    reset: resetModal,
   }
 }

--- a/libs/frontend/modules/lambda/src/use-cases/update-lambda/useUpdateLambdaForm.ts
+++ b/libs/frontend/modules/lambda/src/use-cases/update-lambda/useUpdateLambdaForm.ts
@@ -17,11 +17,8 @@ export const useUpdateLambdaForm = () => {
   })
 
   const onSubmit = useCallback(
-    (input: UpdateLambdaMutationInput) => {
-      return mutate({
-        variables: { input },
-      })
-    },
+    (input: UpdateLambdaMutationInput) =>
+      mutate({ variables: { input } }).unwrap(),
     [mutate, updateId],
   )
 

--- a/libs/frontend/modules/lambda/src/use-cases/update-lambda/useUpdateLambdaForm.ts
+++ b/libs/frontend/modules/lambda/src/use-cases/update-lambda/useUpdateLambdaForm.ts
@@ -6,7 +6,7 @@ import { UpdateLambdaFormProps, UpdateLambdaMutationInput } from './types'
 
 export const useUpdateLambdaForm = () => {
   const { updateId, entity } = useLambdaState()
-  const { reset } = useLambdaDispatch()
+  const { resetModal } = useLambdaDispatch()
 
   const [mutate, state] = useUpdateLambdaMutation({
     selectFromResult: (r) => ({
@@ -29,7 +29,7 @@ export const useUpdateLambdaForm = () => {
     title: 'Error while updateing lambda',
   })
 
-  const onSubmitSuccess = () => reset()
+  const onSubmitSuccess = () => resetModal()
 
   const formProps: UpdateLambdaFormProps = {
     onSubmit,
@@ -45,6 +45,6 @@ export const useUpdateLambdaForm = () => {
   return {
     formProps,
     state,
-    reset,
+    reset: resetModal,
   }
 }

--- a/libs/frontend/modules/page/src/hooks/usePageDispatch.ts
+++ b/libs/frontend/modules/page/src/hooks/usePageDispatch.ts
@@ -1,39 +1,18 @@
+import { crudModalDispatchFactory } from '@codelab/frontend/view/components'
 import { useDispatch } from 'react-redux'
-import {
-  OpenDeletePageModalAction,
-  OpenUpdatePageModalAction,
-  pageSlice,
-  SetCurrentPageAction,
-} from '../store'
+import { pageSlice, SetCurrentPageAction } from '../store'
 
 export const usePageDispatch = () => {
   const dispatch = useDispatch()
   const { actions } = pageSlice
-
-  const openCreateModal = () => {
-    dispatch(actions.openCreateModal())
-  }
-
-  const openDeleteModal = (payload: OpenDeletePageModalAction) =>
-    dispatch(actions.openDeleteModal(payload))
-
-  const openUpdateModal = (payload: OpenUpdatePageModalAction) => {
-    dispatch(actions.openUpdateModal(payload))
-  }
-
-  const reset = () => {
-    dispatch(actions.reset())
-  }
+  const curdDispatch = crudModalDispatchFactory(pageSlice.actions)()
 
   const setCurrentPage = (payload: SetCurrentPageAction) => {
     dispatch(actions.setCurrentPage(payload))
   }
 
   return {
-    openCreateModal,
-    openDeleteModal,
-    openUpdateModal,
     setCurrentPage,
-    reset,
+    ...curdDispatch,
   }
 }

--- a/libs/frontend/modules/page/src/use-cases/create-page/CreatePageButton.tsx
+++ b/libs/frontend/modules/page/src/use-cases/create-page/CreatePageButton.tsx
@@ -6,12 +6,16 @@ import { usePageDispatch } from '../../hooks'
 export const CreatePageButton = () => {
   const { openCreateModal } = usePageDispatch()
 
+  const onClick = () => {
+    openCreateModal()
+  }
+
   return (
     <Button
       type="primary"
       size="small"
       icon={<PlusOutlined />}
-      onClick={openCreateModal}
+      onClick={onClick}
     />
   )
 }

--- a/libs/frontend/modules/page/src/use-cases/create-page/useCreatePageForm.ts
+++ b/libs/frontend/modules/page/src/use-cases/create-page/useCreatePageForm.ts
@@ -8,7 +8,7 @@ import { CreatePageFormProps } from './types'
 
 export const useCreatePageForm = () => {
   const { currentApp } = useAppState()
-  const { reset } = usePageDispatch()
+  const { resetModal } = usePageDispatch()
 
   const [mutate, state] = useCreatePageMutation({
     selectFromResult: (r) => ({
@@ -19,7 +19,7 @@ export const useCreatePageForm = () => {
   })
 
   const onSubmit = useCallback(
-    (input: CreatePageInput) => mutate({ variables: { input } }),
+    (input: CreatePageInput) => mutate({ variables: { input } }).unwrap(),
     [mutate],
   )
 
@@ -27,7 +27,7 @@ export const useCreatePageForm = () => {
     title: 'Error while creating page',
   })
 
-  const onSubmitSuccess = () => reset()
+  const onSubmitSuccess = () => resetModal()
 
   const formProps: CreatePageFormProps = {
     onSubmit,
@@ -39,6 +39,6 @@ export const useCreatePageForm = () => {
   return {
     formProps,
     state,
-    reset,
+    reset: resetModal,
   }
 }

--- a/libs/frontend/modules/page/src/use-cases/delete-page/useDeletePageForm.ts
+++ b/libs/frontend/modules/page/src/use-cases/delete-page/useDeletePageForm.ts
@@ -6,7 +6,7 @@ import { DeletePageFormProps, DeletePageMutationInput } from './types'
 
 export const useDeletePageForm = () => {
   const { deleteIds, entity } = usePageState()
-  const { reset } = usePageDispatch()
+  const { resetModal } = usePageDispatch()
 
   const [mutate, state] = useDeletePageMutation({
     selectFromResult: (r) => ({
@@ -25,7 +25,7 @@ export const useDeletePageForm = () => {
     title: 'Error while deleting page',
   })
 
-  const onSubmitSuccess = () => reset()
+  const onSubmitSuccess = () => resetModal()
 
   const formProps: DeletePageFormProps = {
     onSubmit,
@@ -38,6 +38,6 @@ export const useDeletePageForm = () => {
   return {
     formProps,
     state,
-    reset,
+    reset: resetModal,
   }
 }

--- a/libs/frontend/modules/page/src/use-cases/delete-page/useDeletePageForm.ts
+++ b/libs/frontend/modules/page/src/use-cases/delete-page/useDeletePageForm.ts
@@ -17,7 +17,8 @@ export const useDeletePageForm = () => {
   })
 
   const onSubmit = useCallback(
-    (input: DeletePageMutationInput) => mutate({ variables: { input } }),
+    (input: DeletePageMutationInput) =>
+      mutate({ variables: { input } }).unwrap(),
     [mutate],
   )
 

--- a/libs/frontend/modules/page/src/use-cases/update-page/useUpdateAppForm.ts
+++ b/libs/frontend/modules/page/src/use-cases/update-page/useUpdateAppForm.ts
@@ -19,11 +19,10 @@ export const useUpdatePageForm = () => {
   })
 
   const onSubmit = useCallback(
-    (data: UpdatePageMutationInput) => {
-      return mutate({
+    (data: UpdatePageMutationInput) =>
+      mutate({
         variables: { input: { updateData: data, pageId: updateId } },
-      })
-    },
+      }).unwrap(),
     [mutate, updateId],
   )
 

--- a/libs/frontend/modules/page/src/use-cases/update-page/useUpdateAppForm.ts
+++ b/libs/frontend/modules/page/src/use-cases/update-page/useUpdateAppForm.ts
@@ -8,7 +8,7 @@ import { UpdatePageFormProps, UpdatePageMutationInput } from './types'
 export const useUpdatePageForm = () => {
   const { currentApp } = useAppState()
   const { updateId, entity } = usePageState()
-  const { reset } = usePageDispatch()
+  const { resetModal } = usePageDispatch()
 
   const [mutate, state] = useUpdatePageMutation({
     selectFromResult: (r) => ({
@@ -31,7 +31,7 @@ export const useUpdatePageForm = () => {
     title: 'Error while updateing page',
   })
 
-  const onSubmitSuccess = () => reset()
+  const onSubmitSuccess = () => resetModal()
 
   const formProps: UpdatePageFormProps = {
     onSubmit,
@@ -46,6 +46,6 @@ export const useUpdatePageForm = () => {
   return {
     formProps,
     state,
-    reset,
+    reset: resetModal,
   }
 }

--- a/libs/frontend/modules/tag/src/use-cases/create-tag/useCreateTagForm.ts
+++ b/libs/frontend/modules/tag/src/use-cases/create-tag/useCreateTagForm.ts
@@ -20,7 +20,7 @@ export const useCreateTagForm = (parentTagId?: string) => {
 
   const handleSubmit = useCallback(
     (input: CreateTagInput) => {
-      return mutate({ variables: { input } })
+      return mutate({ variables: { input } }).unwrap()
     },
     [mutate],
   )

--- a/libs/frontend/modules/tag/src/use-cases/delete-tags/useDeleteTagsForm.ts
+++ b/libs/frontend/modules/tag/src/use-cases/delete-tags/useDeleteTagsForm.ts
@@ -20,7 +20,7 @@ export const useDeleteTagForm = () => {
 
   const handleSubmit = useCallback(
     ({ ids }: DeleteTagsSchema) => {
-      return mutate({ variables: { input: { ids } } })
+      return mutate({ variables: { input: { ids } } }).unwrap()
     },
     [mutate],
   )

--- a/libs/frontend/modules/tag/src/use-cases/update-tag/useUpdateTagForm.ts
+++ b/libs/frontend/modules/tag/src/use-cases/update-tag/useUpdateTagForm.ts
@@ -23,7 +23,7 @@ export const useUpdateTagForm = () => {
     ({ name }: UpdateTagSchema) => {
       return mutate({
         variables: { input: { data: { name }, id: updateId } },
-      })
+      }).unwrap()
     },
     [mutate, updateId],
   )

--- a/libs/frontend/modules/type/src/use-cases/fields/create-field/useCreateFieldForm.tsx
+++ b/libs/frontend/modules/type/src/use-cases/fields/create-field/useCreateFieldForm.tsx
@@ -34,7 +34,7 @@ export const useCreateFieldForm = () => {
         },
       }
 
-      return mutate({ variables })
+      return mutate({ variables }).unwrap()
     },
     [interfaceId, mutate],
   )

--- a/libs/frontend/modules/type/src/use-cases/fields/delete-field/useDeleteFieldForm.tsx
+++ b/libs/frontend/modules/type/src/use-cases/fields/delete-field/useDeleteFieldForm.tsx
@@ -16,7 +16,7 @@ export const useDeleteFieldForm = () => {
   })
 
   const handleSubmit = useCallback(() => {
-    return mutate({ variables: { input: { fieldId: deleteIds[0] } } })
+    return mutate({ variables: { input: { fieldId: deleteIds[0] } } }).unwrap()
   }, [deleteIds, mutate])
 
   return {

--- a/libs/frontend/modules/type/src/use-cases/fields/update-field/useUpdateFieldForm.tsx
+++ b/libs/frontend/modules/type/src/use-cases/fields/update-field/useUpdateFieldForm.tsx
@@ -30,7 +30,7 @@ export const useUpdateFieldForm = () => {
         },
       }
 
-      return mutate({ variables: { input } })
+      return mutate({ variables: { input } }).unwrap()
     },
     [updateId, mutate],
   )

--- a/libs/frontend/modules/type/src/use-cases/types/create-type/useCreateTypeForm.tsx
+++ b/libs/frontend/modules/type/src/use-cases/types/create-type/useCreateTypeForm.tsx
@@ -22,7 +22,7 @@ export const useCreateTypeForm = () => {
     (submitData: CreateTypeSchema) => {
       const input = mapCreateTypeSchemaToTypeInput(submitData)
 
-      return mutate({ variables: { input } })
+      return mutate({ variables: { input } }).unwrap()
     },
     [mutate],
   )

--- a/libs/frontend/modules/type/src/use-cases/types/delete-type/useDeleteTypeForm.tsx
+++ b/libs/frontend/modules/type/src/use-cases/types/delete-type/useDeleteTypeForm.tsx
@@ -17,7 +17,7 @@ export const useDeleteTypeForm = () => {
   })
 
   const handleSubmit = useCallback(() => {
-    return mutate({ variables: { input: { typeId } } })
+    return mutate({ variables: { input: { typeId } } }).unwrap()
   }, [mutate, typeId])
 
   return {

--- a/libs/frontend/modules/user/src/uses-cases/delete-user/useDeleteUserForm.ts
+++ b/libs/frontend/modules/user/src/uses-cases/delete-user/useDeleteUserForm.ts
@@ -22,7 +22,7 @@ export const useDeleteUserForm = () => {
     for (const id of deleteIds) {
       await mutate({
         variables: { input: { id } },
-      })
+      }).unwrap()
     }
   }, [mutate])
 

--- a/libs/frontend/shared/utils/src/lib/notifications.ts
+++ b/libs/frontend/shared/utils/src/lib/notifications.ts
@@ -62,11 +62,11 @@ type UseNotifyReturnType = {
 }
 
 export const useNotify = (
-  success: NotificationOptions,
-  error: NotificationOptions,
+  success: Omit<NotificationOptions, 'type'>,
+  error: Omit<NotificationOptions, 'type'>,
 ): UseNotifyReturnType => {
-  const onSuccess = () => notify(success)
-  const onError = () => notify(error)
+  const onSuccess = () => notify({ ...success, type: 'success' })
+  const onError = () => notify({ ...error, type: 'error' })
 
   return { onSuccess, onError }
 }

--- a/libs/frontend/shared/utils/src/lib/notifications.ts
+++ b/libs/frontend/shared/utils/src/lib/notifications.ts
@@ -4,7 +4,7 @@ import { extractErrorMessage } from './extractErrorMessage'
 
 type NotificationType = 'success' | 'info' | 'warning' | 'error'
 
-export interface NotificationOptions<TEvent> {
+export interface NotificationOptions<TEvent = any> {
   /** The type of notification. Default is error */
   type?: NotificationType
   /** Enter a custom title of the notification. If you don't, it will be "info" */
@@ -54,6 +54,21 @@ export const notify = <TEvent>(
   } else {
     console.log(titleString, contentString)
   }
+}
+
+type UseNotifyReturnType = {
+  onSuccess: () => void
+  onError: () => void
+}
+
+export const useNotify = (
+  success: NotificationOptions,
+  error: NotificationOptions,
+): UseNotifyReturnType => {
+  const onSuccess = () => notify(success)
+  const onError = () => notify(error)
+
+  return { onSuccess, onError }
 }
 
 /**


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Current Behavior

- No notification was displayed when importing/seeding BaseTypes/Atoms 
- Upload atoms requires the user to reload the page
- exception were not passed to forms because they are warped by the Rtk library   

## Expected Behavior
- Show notifications on the operations that requires that 
- Invalidate cache on atoms import
- Unwrap the mutation response 

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
